### PR TITLE
feat: `executeQuote` function

### DIFF
--- a/apps/example/scripts/sdk.ts
+++ b/apps/example/scripts/sdk.ts
@@ -33,6 +33,7 @@ async function main() {
     useTestnet: false,
     integratorId: "TEST",
     logLevel: "DEBUG",
+    walletClient,
   });
 
   // do call to find info for displaying input/output tokens and destination chains
@@ -48,7 +49,7 @@ async function main() {
 
   // 3. choose destination chain, mainnet in this example
   const destinationChainDetails = chainDetails.find(
-    (chain) => chain.chainId === mainnet.id,
+    (chain) => chain.chainId === arbitrum.id,
   );
 
   // 4. select input token from dropdown
@@ -77,7 +78,7 @@ async function main() {
   // 1. get quote
   const bridgeQuoteRes = await client.actions.getQuote({
     route,
-    inputAmount: parseUnits("10", usdc.decimals),
+    inputAmount: parseUnits("1", usdc.decimals),
     recipient: account.address,
   });
 
@@ -154,6 +155,19 @@ async function main() {
       }
     };
     // getFillOnLoop()
+  }
+
+  /* -------------------- test with `executeQuote` function ------------------- */
+  if (process.env.USE_EXECUTE_QUOTE === "true") {
+    console.log("\nExecuting quote via `executeQuote` function...");
+    const result = await client.actions.executeQuote({
+      deposit: bridgeQuoteRes.deposit,
+      onProgress: (progress) => {
+        console.log("Progress: ", progress);
+      },
+      infiniteApproval: true,
+    });
+    console.log("Execute quote result: ", result);
   }
 
   /* ------------------------ test cross-chain message ------------------------ */

--- a/packages/sdk/src/actions/executeQuote.ts
+++ b/packages/sdk/src/actions/executeQuote.ts
@@ -1,0 +1,297 @@
+import {
+  parseAbi,
+  SimulateContractReturnType,
+  TransactionReceipt,
+  WalletClient,
+} from "viem";
+
+import { Quote } from "./getQuote";
+import { simulateDepositTx } from "./simulateDepositTx";
+import { LoggerT } from "../utils";
+import { simulateApproveTx } from "./simulateApproveTx";
+import { waitForDepositTx } from "./waitForDepositTx";
+import { ConfiguredPublicClient } from "../types";
+import { waitForFillTx } from "./waitForFillTx";
+
+export type ExecutionProgress =
+  | { status: "idle" }
+  | (ProgressMeta & {
+      status: "txSimulationPending";
+    })
+  | (ProgressMeta & {
+      status: "txSimulationSuccess";
+    })
+  | (ProgressMeta & {
+      status: "txSimulationError";
+      error: Error;
+    })
+  | (ProgressMeta & {
+      status: "txPending";
+      txHash: string;
+    })
+  | (ProgressMeta & {
+      status: "txSuccess";
+      txReceipt: TransactionReceipt;
+    })
+  | (ProgressMeta & {
+      status: "txError";
+      error: Error;
+    })
+  | { status: "error" };
+
+type ProgressMeta = {
+  type: "approve" | "deposit" | "fill";
+  meta: {
+    [key: string]: unknown;
+  };
+};
+
+export type ExecuteQuoteParams = {
+  logger?: LoggerT;
+  integratorId: string;
+  deposit: Quote["deposit"];
+  walletClient: WalletClient;
+  originClient: ConfiguredPublicClient;
+  destinationClient: ConfiguredPublicClient;
+  infiniteApproval?: boolean;
+  skipAllowanceCheck?: boolean;
+  throwOnError?: boolean;
+  onProgress?: (progress: ExecutionProgress) => void;
+};
+
+export async function executeQuote(params: ExecuteQuoteParams) {
+  const {
+    integratorId,
+    deposit,
+    walletClient,
+    originClient,
+    destinationClient,
+    skipAllowanceCheck,
+    infiniteApproval,
+    throwOnError = true,
+    onProgress,
+    logger,
+  } = params;
+
+  const onProgressHandler =
+    onProgress ||
+    ((progress: ExecutionProgress) => defaultProgressHandler(progress, logger));
+
+  let txRequest: Awaited<SimulateContractReturnType>["request"];
+  let currentProgressStatus: ExecutionProgress["status"] = "idle";
+  let currentProgressMeta: ProgressMeta = {
+    type: "approve",
+    meta: {},
+  };
+
+  try {
+    const account = walletClient.account;
+
+    if (!account) {
+      throw new Error("Wallet account has to be set");
+    }
+
+    const { inputToken, inputAmount, spokePoolAddress } = deposit;
+
+    // Handle token approval if necessary. This will:
+    // 1. Check if the allowance is sufficient for SpokePool
+    // 2. If not, simulate an `approve` transaction
+    // 3. If successful, execute the `approve` transaction
+    if (!skipAllowanceCheck && !deposit.isNative) {
+      const allowance = await originClient.readContract({
+        address: inputToken,
+        abi: parseAbi([
+          "function allowance(address owner, address spender) public view returns (uint256)",
+        ]),
+        functionName: "allowance",
+        args: [account.address, spokePoolAddress],
+      });
+      logger?.debug("Allowance", {
+        allowance,
+        owner: account.address,
+        spender: spokePoolAddress,
+        inputToken,
+      });
+
+      if (BigInt(inputAmount) > allowance) {
+        const approvalAmount = infiniteApproval
+          ? BigInt(0xffffffff) // max uint256
+          : BigInt(inputAmount);
+
+        currentProgressMeta = {
+          type: "approve",
+          meta: {
+            approvalAmount,
+            spender: spokePoolAddress,
+          },
+        };
+        currentProgressStatus = "txSimulationPending";
+        onProgressHandler({
+          status: currentProgressStatus,
+          ...currentProgressMeta,
+        });
+
+        const { request } = await simulateApproveTx({
+          walletClient,
+          publicClient: originClient,
+          spender: spokePoolAddress,
+          approvalAmount,
+          tokenAddress: inputToken,
+        });
+        txRequest = request;
+
+        currentProgressStatus = "txSimulationSuccess";
+        onProgressHandler({
+          status: currentProgressStatus,
+          ...currentProgressMeta,
+        });
+
+        const approveTxHash = await walletClient.writeContract({
+          account,
+          ...txRequest,
+        });
+
+        currentProgressStatus = "txPending";
+        onProgressHandler({
+          status: currentProgressStatus,
+          txHash: approveTxHash,
+          ...currentProgressMeta,
+        });
+
+        const approveTxReceipt = await originClient.waitForTransactionReceipt({
+          hash: approveTxHash,
+        });
+
+        currentProgressStatus = "txSuccess";
+        onProgressHandler({
+          status: currentProgressStatus,
+          txReceipt: approveTxReceipt,
+          ...currentProgressMeta,
+        });
+      }
+    }
+
+    // Handle deposit transaction on SpokePool:
+    // 1. Simulate the deposit transaction
+    // 2. If successful, execute the deposit transaction
+    // 3. Wait for the transaction to be mined
+    currentProgressMeta = {
+      type: "deposit",
+      meta: {
+        deposit,
+      },
+    };
+    currentProgressStatus = "txSimulationPending";
+    onProgressHandler({
+      status: currentProgressStatus,
+      ...currentProgressMeta,
+    });
+
+    const { request: _request } = await simulateDepositTx({
+      walletClient,
+      publicClient: originClient,
+      deposit,
+      integratorId,
+      logger,
+    });
+    txRequest = _request;
+
+    currentProgressStatus = "txSimulationSuccess";
+    onProgressHandler({
+      status: currentProgressStatus,
+      ...currentProgressMeta,
+    });
+
+    const depositTxHash = await walletClient.writeContract({
+      account,
+      ...txRequest,
+    });
+    const destinationBlock = await destinationClient.getBlockNumber();
+
+    currentProgressStatus = "txPending";
+    onProgressHandler({
+      status: currentProgressStatus,
+      txHash: depositTxHash,
+      ...currentProgressMeta,
+    });
+
+    const { depositId, depositTxReceipt } = await waitForDepositTx({
+      transactionHash: depositTxHash,
+      publicClient: originClient,
+    });
+
+    currentProgressStatus = "txSuccess";
+    onProgressHandler({
+      status: currentProgressStatus,
+      txReceipt: depositTxReceipt,
+      ...{
+        ...currentProgressMeta,
+        meta: {
+          depositId,
+        },
+      },
+    });
+
+    // After successful deposit, wait for fill
+    currentProgressMeta = {
+      type: "fill",
+      meta: {
+        depositId,
+      },
+    };
+    currentProgressStatus = "txPending";
+    onProgressHandler({
+      status: currentProgressStatus,
+      txHash: depositTxHash,
+      ...currentProgressMeta,
+    });
+
+    const { fillTxReceipt, fillTxTimestamp, actionSuccess } =
+      await waitForFillTx({
+        deposit,
+        depositId,
+        destinationPublicClient: destinationClient,
+        fromBlock: destinationBlock - 100n, // TODO: use dynamic block buffer based chain
+      });
+
+    currentProgressStatus = "txSuccess";
+    onProgressHandler({
+      status: currentProgressStatus,
+      txReceipt: fillTxReceipt,
+      ...{
+        ...currentProgressMeta,
+        meta: {
+          depositId,
+          fillTxTimestamp,
+          actionSuccess,
+        },
+      },
+    });
+    return { depositId, depositTxReceipt, fillTxReceipt };
+  } catch (error) {
+    const errorStatus =
+      currentProgressStatus === "txPending"
+        ? "txError"
+        : currentProgressStatus === "txSimulationPending"
+          ? "txSimulationError"
+          : "error";
+    onProgressHandler({
+      status: errorStatus,
+      error: error as Error,
+      ...currentProgressMeta,
+    });
+
+    if (!throwOnError) {
+      return { error };
+    }
+
+    throw error;
+  }
+}
+
+function defaultProgressHandler(progress: ExecutionProgress, logger?: LoggerT) {
+  if (!logger) {
+    return;
+  }
+  logger.debug("Progress", progress);
+}

--- a/packages/sdk/src/actions/index.ts
+++ b/packages/sdk/src/actions/index.ts
@@ -7,3 +7,5 @@ export * from "./waitForDepositTx";
 export * from "./getFillByDepositTx";
 export * from "./getDepositLogs";
 export * from "./waitForFillTx";
+export * from "./simulateApproveTx";
+export * from "./executeQuote";

--- a/packages/sdk/src/actions/simulateApproveTx.ts
+++ b/packages/sdk/src/actions/simulateApproveTx.ts
@@ -1,0 +1,36 @@
+import {
+  Address,
+  parseAbi,
+  PublicClient,
+  SimulateContractReturnType,
+  WalletClient,
+} from "viem";
+
+export type SimulateApproveTxParams = {
+  walletClient: WalletClient;
+  publicClient: PublicClient;
+  spender: Address;
+  approvalAmount: bigint;
+  tokenAddress: Address;
+};
+
+export async function simulateApproveTx(params: SimulateApproveTxParams) {
+  const { walletClient, publicClient, spender, approvalAmount, tokenAddress } =
+    params;
+
+  if (!walletClient.account) {
+    throw new Error("Wallet account has to be set");
+  }
+
+  const simulationResult = await publicClient.simulateContract({
+    account: walletClient.account,
+    abi: parseAbi([
+      "function approve(address spender, uint256 amount) public returns (bool)",
+    ]),
+    address: tokenAddress,
+    functionName: "approve",
+    args: [spender, approvalAmount],
+  });
+
+  return simulationResult as unknown as SimulateContractReturnType;
+}


### PR DESCRIPTION
Closes ACX-2621

This adds the first version of the `executeQuote` function. It accepts a callback which gets invoked on key progress steps.

I am also working on a more sophisticated version of this, that tracks the progress internally and can be stopped, and resumed. But this will probably in a separate PR 