### PR TITLE
feat: add `client.update` method

### DIFF
--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -136,6 +136,10 @@ export class AcrossClient {
     return this.instance;
   }
 
+  update(params: Pick<AcrossClientOptions, "walletClient">) {
+    this.walletClient = params.walletClient;
+  }
+
   getSupportedChains(
     params: Omit<GetSupportedChainsParams, "apiUrl" | "logger">,
   ) {


### PR DESCRIPTION
Closes ACX-2698

I limited the updatable properties of the client to `walletClient` for now. If we need to whitelist more in the future, we can do so subsequently