### PR TITLE
docs: add TSDoc comments to SpokePool ABI with scope reduction warning

### DIFF
--- a/.changeset/great-avocados-impress.md
+++ b/.changeset/great-avocados-impress.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+add TSDoc comments to SpokePool ABI with scope reduction warning

--- a/packages/sdk/src/abis/SpokePool.ts
+++ b/packages/sdk/src/abis/SpokePool.ts
@@ -1,4 +1,8 @@
-// TODO: remove what we don't use
+/**
+ * @notice ABI definition for the Across Protocol SpokePool contract
+ * @dev WARNING: This ABI may be reduced in scope over time as unused functions are removed
+ * @see {@link https://github.com/across-protocol/contracts/blob/audit-latest/contracts/SpokePool.sol} for the most recent audited contract specification
+ */
 export const spokePoolAbi = [
   { inputs: [], name: "DepositsArePaused", type: "error" },
   { inputs: [], name: "DisabledRoute", type: "error" },


### PR DESCRIPTION
- Add warning about potential future ABI scope reduction
- Include reference to audited contract specification
- Link to latest audited SpokePool contract on GitHub