### PR TITLE
fix pnpm version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "prettier": "^3.2.5",
     "turbo": "^2.1.0"
   },
-  "packageManager": "pnpm@8.15.6",
+  "packageManager": "pnpm@9.15.2",
   "pnpm": {
     "overrides": {
       "secp256k1": "^>=5.0.1"


### PR DESCRIPTION
Should stop dependabot from downgrading the lockfile version, causing the builds to fail.

see this [issue](https://github.com/dependabot/dependabot-core/issues/9684)