### PR TITLE
v3_5 SpokePool upgrade

### DIFF
--- a/.changeset/clever-spoons-type.md
+++ b/.changeset/clever-spoons-type.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": minor
+---
+
+Adds support for minor upgrade in SpokePools.

--- a/apps/example/scripts/sdk.ts
+++ b/apps/example/scripts/sdk.ts
@@ -206,7 +206,7 @@ async function main() {
   const depositById = await client.getDeposit({
     findBy: {
       ...depositFilter,
-      depositId: 2525494,
+      depositId: 2525494n,
     },
   });
   console.log("Deposit by id", depositById);

--- a/packages/sdk/src/abis/SpokePool/index.ts
+++ b/packages/sdk/src/abis/SpokePool/index.ts
@@ -1,0 +1,2 @@
+export * from "./v3.js";
+export * from "./v4.js";

--- a/packages/sdk/src/abis/SpokePool/index.ts
+++ b/packages/sdk/src/abis/SpokePool/index.ts
@@ -1,2 +1,2 @@
 export * from "./v3.js";
-export * from "./v4.js";
+export * from "./v3_5.js";

--- a/packages/sdk/src/abis/SpokePool/v3.ts
+++ b/packages/sdk/src/abis/SpokePool/v3.ts
@@ -3,7 +3,7 @@
  * @dev WARNING: This ABI may be reduced in scope over time as unused functions are removed
  * @see {@link https://github.com/across-protocol/contracts/blob/audit-latest/contracts/SpokePool.sol} for the most recent audited contract specification
  */
-export const spokePoolAbi = [
+export const spokePoolAbiV3 = [
   { inputs: [], name: "DepositsArePaused", type: "error" },
   { inputs: [], name: "DisabledRoute", type: "error" },
   { inputs: [], name: "ExpiredFillDeadline", type: "error" },

--- a/packages/sdk/src/abis/SpokePool/v3_5.ts
+++ b/packages/sdk/src/abis/SpokePool/v3_5.ts
@@ -3,7 +3,7 @@
  * @dev WARNING: This ABI may be reduced in scope over time as unused functions are removed
  * @see {@link https://github.com/across-protocol/contracts/blob/audit-latest/contracts/SpokePool.sol} for the most recent audited contract specification
  */
-export const spokePoolAbiV4 = [
+export const spokePoolAbiV3_5 = [
   {
     inputs: [],
     name: "ClaimedMerkleLeaf",

--- a/packages/sdk/src/abis/SpokePool/v4.ts
+++ b/packages/sdk/src/abis/SpokePool/v4.ts
@@ -1,0 +1,2755 @@
+/**
+ * @notice ABI definition for the Across Protocol SpokePool contract
+ * @dev WARNING: This ABI may be reduced in scope over time as unused functions are removed
+ * @see {@link https://github.com/across-protocol/contracts/blob/audit-latest/contracts/SpokePool.sol} for the most recent audited contract specification
+ */
+export const spokePoolAbiV4 = [
+  {
+    inputs: [],
+    name: "ClaimedMerkleLeaf",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "DepositsArePaused",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "DisabledRoute",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "ExpiredFillDeadline",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "FillsArePaused",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InsufficientSpokePoolBalanceToExecuteLeaf",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidBytes32",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidChainId",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidCrossDomainAdmin",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidDepositorSignature",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidExclusiveRelayer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidFillDeadline",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidMerkleLeaf",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidMerkleProof",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidPayoutAdjustmentPct",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidQuoteTimestamp",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidRelayerFeePct",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidSlowFillRequest",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "InvalidWithdrawalRecipient",
+    type: "error",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "LowLevelCallFailed",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MaxTransferSizeExceeded",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "MsgValueDoesNotMatchInputAmount",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NoRelayerRefundToClaim",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NoSlowFillsInExclusivityWindow",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NotEOA",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "NotExclusiveRelayer",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "RelayFilled",
+    type: "error",
+  },
+  {
+    inputs: [],
+    name: "WrongERC7683OrderId",
+    type: "error",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "previousAdmin",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "newAdmin",
+        type: "address",
+      },
+    ],
+    name: "AdminChanged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "beacon",
+        type: "address",
+      },
+    ],
+    name: "BeaconUpgraded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "l2TokenAddress",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "refundAddress",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "caller",
+        type: "address",
+      },
+    ],
+    name: "ClaimedRelayerRefund",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "rootBundleId",
+        type: "uint256",
+      },
+    ],
+    name: "EmergencyDeletedRootBundle",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "originToken",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "enabled",
+        type: "bool",
+      },
+    ],
+    name: "EnabledDepositRoute",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amountToReturn",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256[]",
+        name: "refundAmounts",
+        type: "uint256[]",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "rootBundleId",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "leafId",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "l2TokenAddress",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address[]",
+        name: "refundAddresses",
+        type: "address[]",
+      },
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "deferredRefunds",
+        type: "bool",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "caller",
+        type: "address",
+      },
+    ],
+    name: "ExecutedRelayerRefundRoot",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "repaymentChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "originChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "relayer",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "messageHash",
+        type: "bytes32",
+      },
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "updatedRecipient",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "updatedMessageHash",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "updatedOutputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "enum V3SpokePoolInterface.FillType",
+            name: "fillType",
+            type: "uint8",
+          },
+        ],
+        indexed: false,
+        internalType: "struct V3SpokePoolInterface.V3RelayExecutionEventInfo",
+        name: "relayExecutionInfo",
+        type: "tuple",
+      },
+    ],
+    name: "FilledRelay",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "inputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "outputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "repaymentChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "originChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "depositId",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "exclusiveRelayer",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "relayer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "updatedRecipient",
+            type: "address",
+          },
+          {
+            internalType: "bytes",
+            name: "updatedMessage",
+            type: "bytes",
+          },
+          {
+            internalType: "uint256",
+            name: "updatedOutputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "enum V3SpokePoolInterface.FillType",
+            name: "fillType",
+            type: "uint8",
+          },
+        ],
+        indexed: false,
+        internalType:
+          "struct V3SpokePoolInterface.LegacyV3RelayExecutionEventInfo",
+        name: "relayExecutionInfo",
+        type: "tuple",
+      },
+    ],
+    name: "FilledV3Relay",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "FundsDeposited",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint8",
+        name: "version",
+        type: "uint8",
+      },
+    ],
+    name: "Initialized",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "isPaused",
+        type: "bool",
+      },
+    ],
+    name: "PausedDeposits",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bool",
+        name: "isPaused",
+        type: "bool",
+      },
+    ],
+    name: "PausedFills",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "rootBundleId",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "relayerRefundRoot",
+        type: "bytes32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "slowRelayRoot",
+        type: "bytes32",
+      },
+    ],
+    name: "RelayedRootBundle",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "originChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "messageHash",
+        type: "bytes32",
+      },
+    ],
+    name: "RequestedSlowFill",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "updatedOutputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes32",
+        name: "updatedRecipient",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "updatedMessage",
+        type: "bytes",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "depositorSignature",
+        type: "bytes",
+      },
+    ],
+    name: "RequestedSpeedUpDeposit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "updatedOutputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "depositId",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "updatedRecipient",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "updatedMessage",
+        type: "bytes",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "depositorSignature",
+        type: "bytes",
+      },
+    ],
+    name: "RequestedSpeedUpV3Deposit",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "inputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "outputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "originChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "depositId",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "exclusiveRelayer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "RequestedV3SlowFill",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newWithdrawalRecipient",
+        type: "address",
+      },
+    ],
+    name: "SetWithdrawalRecipient",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "newAdmin",
+        type: "address",
+      },
+    ],
+    name: "SetXDomainAdmin",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "amountToReturn",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "chainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "leafId",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "bytes32",
+        name: "l2TokenAddress",
+        type: "bytes32",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "caller",
+        type: "address",
+      },
+    ],
+    name: "TokensBridged",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "implementation",
+        type: "address",
+      },
+    ],
+    name: "Upgraded",
+    type: "event",
+  },
+  {
+    anonymous: false,
+    inputs: [
+      {
+        indexed: false,
+        internalType: "address",
+        name: "inputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "outputToken",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        indexed: true,
+        internalType: "uint32",
+        name: "depositId",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: false,
+        internalType: "uint32",
+        name: "exclusivityDeadline",
+        type: "uint32",
+      },
+      {
+        indexed: true,
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "address",
+        name: "exclusiveRelayer",
+        type: "address",
+      },
+      {
+        indexed: false,
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "V3FundsDeposited",
+    type: "event",
+  },
+  {
+    inputs: [],
+    name: "EMPTY_RELAYER",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "EMPTY_REPAYMENT_CHAIN_ID",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "INFINITE_FILL_DEADLINE",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "MAX_EXCLUSIVITY_PERIOD_SECONDS",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "MAX_TRANSFER_SIZE",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "UPDATE_ADDRESS_DEPOSIT_DETAILS_HASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "UPDATE_BYTES32_DEPOSIT_DETAILS_HASH",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "_initialDepositId",
+        type: "uint32",
+      },
+      {
+        internalType: "address",
+        name: "_crossDomainAdmin",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "_withdrawalRecipient",
+        type: "address",
+      },
+    ],
+    name: "__SpokePool_init",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "chainId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "l2TokenAddress",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "refundAddress",
+        type: "bytes32",
+      },
+    ],
+    name: "claimRelayerRefund",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "crossDomainAdmin",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "exclusivityParameter",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "deposit",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "originToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "int64",
+        name: "relayerFeePct",
+        type: "int64",
+      },
+      {
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "depositDeprecated_5947912356",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "originToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "amount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "int64",
+        name: "relayerFeePct",
+        type: "int64",
+      },
+      {
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "depositFor",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint32",
+        name: "fillDeadlineOffset",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "exclusivityPeriod",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "depositNow",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "depositQuoteTimeBuffer",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "inputToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "outputToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "exclusiveRelayer",
+        type: "address",
+      },
+      {
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "exclusivityParameter",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "depositV3",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "recipient",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "inputToken",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "outputToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "exclusiveRelayer",
+        type: "address",
+      },
+      {
+        internalType: "uint32",
+        name: "fillDeadlineOffset",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "exclusivityPeriod",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "depositV3Now",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "rootBundleId",
+        type: "uint256",
+      },
+    ],
+    name: "emergencyDeleteRootBundle",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "enabledDepositRoutes",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint32",
+        name: "rootBundleId",
+        type: "uint32",
+      },
+      {
+        components: [
+          {
+            internalType: "uint256",
+            name: "amountToReturn",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "chainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256[]",
+            name: "refundAmounts",
+            type: "uint256[]",
+          },
+          {
+            internalType: "uint32",
+            name: "leafId",
+            type: "uint32",
+          },
+          {
+            internalType: "address",
+            name: "l2TokenAddress",
+            type: "address",
+          },
+          {
+            internalType: "address[]",
+            name: "refundAddresses",
+            type: "address[]",
+          },
+        ],
+        internalType: "struct SpokePoolInterface.RelayerRefundLeaf",
+        name: "relayerRefundLeaf",
+        type: "tuple",
+      },
+      {
+        internalType: "bytes32[]",
+        name: "proof",
+        type: "bytes32[]",
+      },
+    ],
+    name: "executeRelayerRefundLeaf",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            components: [
+              {
+                internalType: "bytes32",
+                name: "depositor",
+                type: "bytes32",
+              },
+              {
+                internalType: "bytes32",
+                name: "recipient",
+                type: "bytes32",
+              },
+              {
+                internalType: "bytes32",
+                name: "exclusiveRelayer",
+                type: "bytes32",
+              },
+              {
+                internalType: "bytes32",
+                name: "inputToken",
+                type: "bytes32",
+              },
+              {
+                internalType: "bytes32",
+                name: "outputToken",
+                type: "bytes32",
+              },
+              {
+                internalType: "uint256",
+                name: "inputAmount",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "outputAmount",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "originChainId",
+                type: "uint256",
+              },
+              {
+                internalType: "uint256",
+                name: "depositId",
+                type: "uint256",
+              },
+              {
+                internalType: "uint32",
+                name: "fillDeadline",
+                type: "uint32",
+              },
+              {
+                internalType: "uint32",
+                name: "exclusivityDeadline",
+                type: "uint32",
+              },
+              {
+                internalType: "bytes",
+                name: "message",
+                type: "bytes",
+              },
+            ],
+            internalType: "struct V3SpokePoolInterface.V3RelayData",
+            name: "relayData",
+            type: "tuple",
+          },
+          {
+            internalType: "uint256",
+            name: "chainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "updatedOutputAmount",
+            type: "uint256",
+          },
+        ],
+        internalType: "struct V3SpokePoolInterface.V3SlowFill",
+        name: "slowFillLeaf",
+        type: "tuple",
+      },
+      {
+        internalType: "uint32",
+        name: "rootBundleId",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes32[]",
+        name: "proof",
+        type: "bytes32[]",
+      },
+    ],
+    name: "executeSlowRelayLeaf",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "orderId",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "originData",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "fillerData",
+        type: "bytes",
+      },
+    ],
+    name: "fill",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "fillDeadlineBuffer",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "depositor",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "recipient",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "exclusiveRelayer",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "inputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "outputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "depositId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct V3SpokePoolInterface.V3RelayData",
+        name: "relayData",
+        type: "tuple",
+      },
+      {
+        internalType: "uint256",
+        name: "repaymentChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "repaymentAddress",
+        type: "bytes32",
+      },
+    ],
+    name: "fillRelay",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "depositor",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "recipient",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "exclusiveRelayer",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "inputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "outputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "depositId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct V3SpokePoolInterface.V3RelayData",
+        name: "relayData",
+        type: "tuple",
+      },
+      {
+        internalType: "uint256",
+        name: "repaymentChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "repaymentAddress",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "updatedOutputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "updatedRecipient",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "updatedMessage",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "depositorSignature",
+        type: "bytes",
+      },
+    ],
+    name: "fillRelayWithUpdatedDeposit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    name: "fillStatuses",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "address",
+            name: "depositor",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "recipient",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "exclusiveRelayer",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "inputToken",
+            type: "address",
+          },
+          {
+            internalType: "address",
+            name: "outputToken",
+            type: "address",
+          },
+          {
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint32",
+            name: "depositId",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct V3SpokePoolInterface.V3RelayDataLegacy",
+        name: "relayData",
+        type: "tuple",
+      },
+      {
+        internalType: "uint256",
+        name: "repaymentChainId",
+        type: "uint256",
+      },
+    ],
+    name: "fillV3Relay",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "getCurrentTime",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "l2TokenAddress",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "refundAddress",
+        type: "address",
+      },
+    ],
+    name: "getRelayerRefund",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "msgSender",
+        type: "address",
+      },
+      {
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "depositNonce",
+        type: "uint256",
+      },
+    ],
+    name: "getUnsafeDepositId",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "pure",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes[]",
+        name: "data",
+        type: "bytes[]",
+      },
+    ],
+    name: "multicall",
+    outputs: [
+      {
+        internalType: "bytes[]",
+        name: "results",
+        type: "bytes[]",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "numberOfDeposits",
+    outputs: [
+      {
+        internalType: "uint32",
+        name: "",
+        type: "uint32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "pause",
+        type: "bool",
+      },
+    ],
+    name: "pauseDeposits",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bool",
+        name: "pause",
+        type: "bool",
+      },
+    ],
+    name: "pauseFills",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pausedDeposits",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "pausedFills",
+    outputs: [
+      {
+        internalType: "bool",
+        name: "",
+        type: "bool",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "proxiableUUID",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "relayerRefundRoot",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "slowRelayRoot",
+        type: "bytes32",
+      },
+    ],
+    name: "relayRootBundle",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    name: "relayerRefund",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        components: [
+          {
+            internalType: "bytes32",
+            name: "depositor",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "recipient",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "exclusiveRelayer",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "inputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "bytes32",
+            name: "outputToken",
+            type: "bytes32",
+          },
+          {
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint256",
+            name: "depositId",
+            type: "uint256",
+          },
+          {
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct V3SpokePoolInterface.V3RelayData",
+        name: "relayData",
+        type: "tuple",
+      },
+    ],
+    name: "requestSlowFill",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    name: "rootBundles",
+    outputs: [
+      {
+        internalType: "bytes32",
+        name: "slowRelayRoot",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "relayerRefundRoot",
+        type: "bytes32",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newCrossDomainAdmin",
+        type: "address",
+      },
+    ],
+    name: "setCrossDomainAdmin",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "originToken",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bool",
+        name: "enabled",
+        type: "bool",
+      },
+    ],
+    name: "setEnableRoute",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newWithdrawalRecipient",
+        type: "address",
+      },
+    ],
+    name: "setWithdrawalRecipient",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "updatedOutputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "updatedRecipient",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes",
+        name: "updatedMessage",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "depositorSignature",
+        type: "bytes",
+      },
+    ],
+    name: "speedUpDeposit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "depositor",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "depositId",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "updatedOutputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "address",
+        name: "updatedRecipient",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "updatedMessage",
+        type: "bytes",
+      },
+      {
+        internalType: "bytes",
+        name: "depositorSignature",
+        type: "bytes",
+      },
+    ],
+    name: "speedUpV3Deposit",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes[]",
+        name: "data",
+        type: "bytes[]",
+      },
+    ],
+    name: "tryMulticall",
+    outputs: [
+      {
+        components: [
+          {
+            internalType: "bool",
+            name: "success",
+            type: "bool",
+          },
+          {
+            internalType: "bytes",
+            name: "returnData",
+            type: "bytes",
+          },
+        ],
+        internalType: "struct MultiCallerUpgradeable.Result[]",
+        name: "results",
+        type: "tuple[]",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "bytes32",
+        name: "depositor",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "recipient",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "inputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "bytes32",
+        name: "outputToken",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "inputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "outputAmount",
+        type: "uint256",
+      },
+      {
+        internalType: "uint256",
+        name: "destinationChainId",
+        type: "uint256",
+      },
+      {
+        internalType: "bytes32",
+        name: "exclusiveRelayer",
+        type: "bytes32",
+      },
+      {
+        internalType: "uint256",
+        name: "depositNonce",
+        type: "uint256",
+      },
+      {
+        internalType: "uint32",
+        name: "quoteTimestamp",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "fillDeadline",
+        type: "uint32",
+      },
+      {
+        internalType: "uint32",
+        name: "exclusivityParameter",
+        type: "uint32",
+      },
+      {
+        internalType: "bytes",
+        name: "message",
+        type: "bytes",
+      },
+    ],
+    name: "unsafeDeposit",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+    ],
+    name: "upgradeTo",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "newImplementation",
+        type: "address",
+      },
+      {
+        internalType: "bytes",
+        name: "data",
+        type: "bytes",
+      },
+    ],
+    name: "upgradeToAndCall",
+    outputs: [],
+    stateMutability: "payable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "withdrawalRecipient",
+    outputs: [
+      {
+        internalType: "address",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "wrappedNativeToken",
+    outputs: [
+      {
+        internalType: "contract WETH9Interface",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    stateMutability: "payable",
+    type: "receive",
+  },
+] as const;

--- a/packages/sdk/src/actions/executeQuote.ts
+++ b/packages/sdk/src/actions/executeQuote.ts
@@ -2,6 +2,7 @@ import {
   Address,
   Hash,
   Hex,
+  maxUint256,
   parseAbi,
   SimulateContractReturnType,
   TransactionReceipt,
@@ -239,7 +240,7 @@ export async function executeQuote(params: ExecuteQuoteParams) {
 
       if (BigInt(inputAmount) > allowance) {
         const approvalAmount = infiniteApproval
-          ? BigInt(0xffffffff) // max uint256
+          ? maxUint256
           : BigInt(inputAmount);
 
         currentProgressMeta = {

--- a/packages/sdk/src/actions/getDeposit.ts
+++ b/packages/sdk/src/actions/getDeposit.ts
@@ -1,5 +1,5 @@
 import { Address, Hex, isHash } from "viem";
-import { getDepositFromLogs } from "./getDepositFromLogs.js";
+import { getDepositFromLogs, parseDepositLogs } from "./getDepositFromLogs.js";
 import { ConfiguredPublicClient, Deposit } from "../types/index.js";
 import { getFillByDepositTx } from "./getFillByDepositTx.js";
 import { NoFillLogError } from "../errors/index.js";
@@ -13,7 +13,7 @@ export type GetDepositParams = {
     destinationSpokePoolAddress: Address;
   } & Partial<{
     originSpokePoolAddress: Address;
-    depositId: number;
+    depositId: bigint;
     depositTxHash: Hex;
   }>;
   depositLogFromBlock?: bigint;
@@ -73,11 +73,85 @@ export async function getDeposit(
 
     rawDeposit = getDepositFromLogs({ originChainId, receipt });
   }
+
   // Try to get deposit from logs by deposit id and spoke pool address on origin chain
   else if (findBy.depositId && findBy.originSpokePoolAddress) {
-    const { originSpokePoolAddress, depositId } = findBy;
+    const { depositId, originSpokePoolAddress } = findBy;
 
-    const [depositEvent] = await originChainClient.getLogs({
+    const depositLogs = await getDepositLogs({
+      depositId,
+      depositLogFromBlock,
+      originChainClient: params.originChainClient,
+      originSpokePoolAddress,
+    });
+
+    if (!depositLogs?.length) {
+      throw new Error(`No deposit logs found for deposit id: ${depositId}`);
+    }
+
+    const parsedDepositLog = parseDepositLogs(depositLogs);
+
+    if (!parsedDepositLog) {
+      throw new Error(
+        `Unable to parse Deposit logs for deposit id: ${depositId}`,
+      );
+    }
+
+    rawDeposit = {
+      ...parsedDepositLog,
+      depositId,
+      originChainId,
+    };
+  }
+
+  if (!rawDeposit) {
+    throw new Error(`No deposit found for ${JSON.stringify(findBy)}`);
+  }
+
+  try {
+    const fill = await getFillByDepositTx({
+      deposit: {
+        depositId: rawDeposit.depositId,
+        originChainId: rawDeposit.originChainId,
+        destinationSpokePoolAddress,
+        message: rawDeposit.message,
+        depositTxHash: rawDeposit.depositTxHash,
+        destinationChainId: rawDeposit.destinationChainId,
+      },
+      fromBlock: fillLogFromBlock,
+      destinationChainClient,
+      indexerUrl,
+    });
+    rawDeposit.fillTxHash = fill.fillTxReceipt.transactionHash;
+    rawDeposit.fillTxBlock = fill.fillTxReceipt.blockNumber;
+    rawDeposit.status = "filled";
+    rawDeposit.actionSuccess = fill.actionSuccess;
+  } catch (e) {
+    if (e instanceof NoFillLogError) {
+      // if no fill log, deposit is pending
+    } else {
+      throw e;
+    }
+  }
+
+  // TODO: enrich with token details, format amounts, etc.
+  return rawDeposit;
+}
+
+// Look for v3 & v4 deposit logs
+async function getDepositLogs({
+  depositId,
+  depositLogFromBlock,
+  originChainClient,
+  originSpokePoolAddress,
+}: {
+  depositId: bigint;
+  depositLogFromBlock: bigint | undefined;
+  originChainClient: ConfiguredPublicClient;
+  originSpokePoolAddress: Address;
+}) {
+  const [v3Logs, v4Logs] = await Promise.all([
+    originChainClient.getLogs({
       address: originSpokePoolAddress,
       event: {
         anonymous: false,
@@ -165,66 +239,103 @@ export async function getDeposit(
         type: "event",
       },
       args: {
+        depositId: Number(depositId),
+      },
+      fromBlock: depositLogFromBlock ?? 0n,
+    }),
+    originChainClient.getLogs({
+      address: originSpokePoolAddress,
+      event: {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "inputToken",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "outputToken",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint256",
+            name: "destinationChainId",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint256",
+            name: "depositId",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "quoteTimestamp",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: true,
+            internalType: "bytes32",
+            name: "depositor",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "recipient",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "exclusiveRelayer",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+        ],
+        name: "FundsDeposited",
+        type: "event",
+      },
+      args: {
         depositId,
       },
       fromBlock: depositLogFromBlock ?? 0n,
-    });
+    }),
+  ]);
 
-    if (!depositEvent) {
-      throw new Error(`No deposit found for deposit id: ${depositId}`);
-    }
-
-    rawDeposit = {
-      depositId,
-      originChainId,
-      inputToken: depositEvent.args.inputToken!,
-      outputToken: depositEvent.args.outputToken!,
-      inputAmount: depositEvent.args.inputAmount!,
-      outputAmount: depositEvent.args.outputAmount!,
-      destinationChainId: Number(depositEvent.args.destinationChainId!),
-      quoteTimestamp: depositEvent.args.quoteTimestamp!,
-      fillDeadline: depositEvent.args.fillDeadline!,
-      exclusivityDeadline: depositEvent.args.exclusivityDeadline!,
-      depositor: depositEvent.args.depositor!,
-      recipient: depositEvent.args.recipient!,
-      exclusiveRelayer: depositEvent.args.exclusiveRelayer!,
-      message: depositEvent.args.message!,
-      status: "pending",
-      depositTxHash: depositEvent.transactionHash,
-      depositTxBlock: depositEvent.blockNumber,
-    };
-  }
-
-  if (!rawDeposit) {
-    throw new Error(`No deposit found for ${JSON.stringify(findBy)}`);
-  }
-
-  try {
-    const fill = await getFillByDepositTx({
-      deposit: {
-        depositId: rawDeposit.depositId,
-        originChainId: rawDeposit.originChainId,
-        destinationSpokePoolAddress,
-        message: rawDeposit.message,
-        depositTxHash: rawDeposit.depositTxHash,
-        destinationChainId: rawDeposit.destinationChainId,
-      },
-      fromBlock: fillLogFromBlock,
-      destinationChainClient,
-      indexerUrl,
-    });
-    rawDeposit.fillTxHash = fill.fillTxReceipt.transactionHash;
-    rawDeposit.fillTxBlock = fill.fillTxReceipt.blockNumber;
-    rawDeposit.status = "filled";
-    rawDeposit.actionSuccess = fill.actionSuccess;
-  } catch (e) {
-    if (e instanceof NoFillLogError) {
-      // if no fill log, deposit is pending
-    } else {
-      throw e;
-    }
-  }
-
-  // TODO: enrich with token details, format amounts, etc.
-  return rawDeposit;
+  return v4Logs ?? v3Logs ?? undefined;
 }

--- a/packages/sdk/src/actions/getDeposit.ts
+++ b/packages/sdk/src/actions/getDeposit.ts
@@ -150,7 +150,7 @@ async function getDepositLogs({
   originChainClient: ConfiguredPublicClient;
   originSpokePoolAddress: Address;
 }) {
-  const [v3Logs, v4Logs] = await Promise.all([
+  const logs = await Promise.race([
     originChainClient.getLogs({
       address: originSpokePoolAddress,
       event: {
@@ -337,5 +337,5 @@ async function getDepositLogs({
     }),
   ]);
 
-  return v4Logs ?? v3Logs ?? undefined;
+  return logs;
 }

--- a/packages/sdk/src/actions/getDeposit.ts
+++ b/packages/sdk/src/actions/getDeposit.ts
@@ -150,7 +150,7 @@ async function getDepositLogs({
   originChainClient: ConfiguredPublicClient;
   originSpokePoolAddress: Address;
 }) {
-  const logs = await Promise.race([
+  const [v3Logs, v4Logs] = await Promise.all([
     originChainClient.getLogs({
       address: originSpokePoolAddress,
       event: {
@@ -337,5 +337,5 @@ async function getDepositLogs({
     }),
   ]);
 
-  return logs;
+  return v3Logs ?? v4Logs;
 }

--- a/packages/sdk/src/actions/getDepositFromLogs.ts
+++ b/packages/sdk/src/actions/getDepositFromLogs.ts
@@ -1,6 +1,7 @@
-import { Address, parseEventLogs, TransactionReceipt } from "viem";
-import { spokePoolAbi } from "../abis/SpokePool.js";
-import { Deposit } from "../types/index.js";
+import { Address, Log, parseEventLogs, TransactionReceipt } from "viem";
+import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { Deposit, DepositLog } from "../types/index.js";
+import { bytes32ToAddress } from "../utils/hex.js";
 
 export type GetDepositLogsParams = {
   originChainId: number;
@@ -14,47 +15,94 @@ export type GetDepositLogsParams = {
   }>;
 };
 
-export type GetDepositLogsReturnType = ReturnType<typeof getDepositFromLogs>;
+export type GetDepositLogsReturnType = ReturnType<typeof parseDepositLogs>;
 
-export function getDepositFromLogs({
-  originChainId,
-  receipt,
-  filter,
-}: GetDepositLogsParams): Deposit | undefined {
-  const parsedLogs = parseEventLogs({
-    abi: spokePoolAbi,
-    eventName: "V3FundsDeposited",
-    logs: receipt.logs,
+export function parseDepositLogs(
+  logs: Log[],
+  filter?: Partial<{
+    inputToken: Address;
+    outputToken: Address;
+    destinationChainId: bigint;
+    inputAmount: bigint;
+    outputAmount: bigint;
+  }>,
+): DepositLog | undefined {
+  const blockData = {
+    depositTxHash: logs[0]!.blockHash!,
+    depositTxBlock: logs[0]!.blockNumber!,
+  };
+  // Parse V4 Logs
+  const parsedV4Logs = parseEventLogs({
+    abi: spokePoolAbiV4,
+    eventName: "FundsDeposited",
+    logs,
     args: filter,
   });
 
-  if (parsedLogs.length > 1) {
-    throw new Error("Multiple deposit logs found. Specify filter");
+  const v4Log = parsedV4Logs?.[0];
+  if (v4Log) {
+    return {
+      ...blockData,
+      depositId: v4Log.args.depositId,
+      inputToken: bytes32ToAddress(v4Log.args.inputToken),
+      outputToken: bytes32ToAddress(v4Log.args.outputToken),
+      inputAmount: v4Log.args.inputAmount,
+      outputAmount: v4Log.args.outputAmount,
+      destinationChainId: Number(v4Log.args.destinationChainId),
+      message: v4Log.args.message,
+      depositor: bytes32ToAddress(v4Log.args.depositor),
+      recipient: bytes32ToAddress(v4Log.args.recipient),
+      exclusiveRelayer: bytes32ToAddress(v4Log.args.exclusiveRelayer),
+      quoteTimestamp: v4Log.args.quoteTimestamp,
+      fillDeadline: v4Log.args.fillDeadline,
+      exclusivityDeadline: v4Log.args.exclusivityDeadline,
+      status: "pending",
+    };
   }
 
-  const depositLog = parsedLogs[0];
+  // Parse V3 Logs
+  const parsedV3Logs = parseEventLogs({
+    abi: spokePoolAbiV4,
+    eventName: "V3FundsDeposited",
+    logs,
+    args: filter,
+  });
+  const v3Log = parsedV3Logs?.[0];
+  if (v3Log) {
+    return {
+      ...blockData,
+      depositId: BigInt(v3Log.args.depositId),
+      inputToken: v3Log.args.inputToken,
+      outputToken: v3Log.args.outputToken,
+      inputAmount: v3Log.args.inputAmount,
+      outputAmount: v3Log.args.outputAmount,
+      destinationChainId: Number(v3Log.args.destinationChainId),
+      message: v3Log.args.message,
+      depositor: v3Log.args.depositor,
+      recipient: v3Log.args.recipient,
+      exclusiveRelayer: v3Log.args.exclusiveRelayer,
+      quoteTimestamp: v3Log.args.quoteTimestamp,
+      fillDeadline: v3Log.args.fillDeadline,
+      exclusivityDeadline: v3Log.args.exclusivityDeadline,
+      status: "pending",
+    };
+  }
 
-  if (!depositLog) {
-    return undefined;
+  return undefined;
+}
+
+export function getDepositFromLogs(params: GetDepositLogsParams): Deposit {
+  const { originChainId, receipt, filter } = params;
+  const standardizedDeposit = parseDepositLogs(receipt.logs, filter);
+
+  if (!standardizedDeposit) {
+    throw new Error("No deposit log found.");
   }
 
   return {
-    depositId: depositLog.args.depositId,
+    ...standardizedDeposit,
     depositTxHash: receipt.transactionHash,
     depositTxBlock: receipt.blockNumber,
-    originChainId,
-    destinationChainId: Number(depositLog.args.destinationChainId),
-    inputToken: depositLog.args.inputToken,
-    outputToken: depositLog.args.outputToken,
-    inputAmount: depositLog.args.inputAmount,
-    outputAmount: depositLog.args.outputAmount,
-    quoteTimestamp: depositLog.args.quoteTimestamp,
-    fillDeadline: depositLog.args.fillDeadline,
-    exclusivityDeadline: depositLog.args.exclusivityDeadline,
-    depositor: depositLog.args.depositor,
-    recipient: depositLog.args.recipient,
-    exclusiveRelayer: depositLog.args.exclusiveRelayer,
-    message: depositLog.args.message,
-    status: "pending",
+    originChainId: originChainId,
   };
 }

--- a/packages/sdk/src/actions/getDepositFromLogs.ts
+++ b/packages/sdk/src/actions/getDepositFromLogs.ts
@@ -1,5 +1,5 @@
 import { Address, Log, parseEventLogs, TransactionReceipt } from "viem";
-import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3_5 } from "../abis/SpokePool/index.js";
 import { Deposit, DepositLog } from "../types/index.js";
 import { bytes32ToAddress } from "../utils/hex.js";
 
@@ -31,38 +31,38 @@ export function parseDepositLogs(
     depositTxHash: logs[0]!.blockHash!,
     depositTxBlock: logs[0]!.blockNumber!,
   };
-  // Parse V4 Logs
-  const parsedV4Logs = parseEventLogs({
-    abi: spokePoolAbiV4,
+  // Parse V3_5 Logs
+  const parsedV3_5Logs = parseEventLogs({
+    abi: spokePoolAbiV3_5,
     eventName: "FundsDeposited",
     logs,
     args: filter,
   });
 
-  const v4Log = parsedV4Logs?.[0];
-  if (v4Log) {
+  const v3_5Log = parsedV3_5Logs?.[0];
+  if (v3_5Log) {
     return {
       ...blockData,
-      depositId: v4Log.args.depositId,
-      inputToken: bytes32ToAddress(v4Log.args.inputToken),
-      outputToken: bytes32ToAddress(v4Log.args.outputToken),
-      inputAmount: v4Log.args.inputAmount,
-      outputAmount: v4Log.args.outputAmount,
-      destinationChainId: Number(v4Log.args.destinationChainId),
-      message: v4Log.args.message,
-      depositor: bytes32ToAddress(v4Log.args.depositor),
-      recipient: bytes32ToAddress(v4Log.args.recipient),
-      exclusiveRelayer: bytes32ToAddress(v4Log.args.exclusiveRelayer),
-      quoteTimestamp: v4Log.args.quoteTimestamp,
-      fillDeadline: v4Log.args.fillDeadline,
-      exclusivityDeadline: v4Log.args.exclusivityDeadline,
+      depositId: v3_5Log.args.depositId,
+      inputToken: bytes32ToAddress(v3_5Log.args.inputToken),
+      outputToken: bytes32ToAddress(v3_5Log.args.outputToken),
+      inputAmount: v3_5Log.args.inputAmount,
+      outputAmount: v3_5Log.args.outputAmount,
+      destinationChainId: Number(v3_5Log.args.destinationChainId),
+      message: v3_5Log.args.message,
+      depositor: bytes32ToAddress(v3_5Log.args.depositor),
+      recipient: bytes32ToAddress(v3_5Log.args.recipient),
+      exclusiveRelayer: bytes32ToAddress(v3_5Log.args.exclusiveRelayer),
+      quoteTimestamp: v3_5Log.args.quoteTimestamp,
+      fillDeadline: v3_5Log.args.fillDeadline,
+      exclusivityDeadline: v3_5Log.args.exclusivityDeadline,
       status: "pending",
     };
   }
 
   // Parse V3 Logs
   const parsedV3Logs = parseEventLogs({
-    abi: spokePoolAbiV4,
+    abi: spokePoolAbiV3_5,
     eventName: "V3FundsDeposited",
     logs,
     args: filter,

--- a/packages/sdk/src/actions/getFillByDepositTx.ts
+++ b/packages/sdk/src/actions/getFillByDepositTx.ts
@@ -165,7 +165,7 @@ export async function waitForFillByDepositTx(
 
 export async function getFillLogs(params: GetFillByDepositTxParams) {
   const { deposit, fromBlock, destinationChainClient } = params;
-  const logs = await Promise.race([
+  const [v3Logs, v4Logs] = await Promise.all([
     destinationChainClient.getLogs({
       address: deposit.destinationSpokePoolAddress,
 
@@ -422,5 +422,5 @@ export async function getFillLogs(params: GetFillByDepositTxParams) {
     }),
   ]);
 
-  return logs;
+  return v3Logs ?? v4Logs;
 }

--- a/packages/sdk/src/actions/getFillByDepositTx.ts
+++ b/packages/sdk/src/actions/getFillByDepositTx.ts
@@ -15,7 +15,7 @@ import { parseFillLogs } from "./waitForFillTx.js";
 
 export type GetFillByDepositTxParams = {
   deposit: {
-    depositId: bigint;
+    depositId: bigint | number;
     depositTxHash?: Hash;
     originChainId: number;
     destinationChainId: number;
@@ -37,7 +37,7 @@ export async function getFillByDepositTx(
     const data = await fetchIndexerApi<IndexerStatusResponse>(
       `${indexerUrl}/deposit/status`,
       {
-        depositId: params.deposit.depositId,
+        depositId: BigInt(params.deposit.depositId),
         originChainId: params.deposit.originChainId,
       },
     );
@@ -87,7 +87,7 @@ export async function getFillByDepositTx(
 
   if (!fillEvent) {
     throw new NoFillLogError(
-      params.deposit.depositId,
+      BigInt(params.deposit.depositId),
       params.deposit.destinationChainId,
       params.deposit.depositTxHash,
     );
@@ -165,7 +165,7 @@ export async function waitForFillByDepositTx(
 
 export async function getFillLogs(params: GetFillByDepositTxParams) {
   const { deposit, fromBlock, destinationChainClient } = params;
-  const [v3Logs, v4Logs] = await Promise.all([
+  const [v3Logs, v3_5Logs] = await Promise.all([
     destinationChainClient.getLogs({
       address: deposit.destinationSpokePoolAddress,
 
@@ -415,12 +415,12 @@ export async function getFillLogs(params: GetFillByDepositTxParams) {
         type: "event",
       },
       args: {
-        depositId: deposit.depositId,
+        depositId: BigInt(deposit.depositId),
         originChainId: BigInt(deposit.originChainId),
       },
       fromBlock: fromBlock ?? 0n,
     }),
   ]);
 
-  return v3Logs ?? v4Logs;
+  return v3Logs ?? v3_5Logs;
 }

--- a/packages/sdk/src/actions/getFillByDepositTx.ts
+++ b/packages/sdk/src/actions/getFillByDepositTx.ts
@@ -14,7 +14,7 @@ import { IndexerStatusResponse } from "../types/index.js";
 
 export type GetFillByDepositTxParams = {
   deposit: {
-    depositId: number;
+    depositId: bigint;
     depositTxHash?: Hash;
     originChainId: number;
     destinationChainId: number;
@@ -201,7 +201,7 @@ export async function getFillByDepositTx(
       type: "event",
     },
     args: {
-      depositId: deposit.depositId,
+      depositId: Number(deposit.depositId),
       originChainId: BigInt(deposit.originChainId),
     },
     fromBlock: fromBlock ?? 0n,

--- a/packages/sdk/src/actions/getFillByDepositTx.ts
+++ b/packages/sdk/src/actions/getFillByDepositTx.ts
@@ -10,7 +10,8 @@ import {
 } from "viem";
 import { MAINNET_INDEXER_API } from "../constants/index.js";
 import { NoFillLogError } from "../errors/index.js";
-import { IndexerStatusResponse } from "../types/index.js";
+import { FillEventLog, IndexerStatusResponse } from "../types/index.js";
+import { parseFillLogs } from "./waitForFillTx.js";
 
 export type GetFillByDepositTxParams = {
   deposit: {
@@ -30,33 +31,30 @@ export type GetFillByDepositTxParams = {
 export async function getFillByDepositTx(
   params: GetFillByDepositTxParams,
 ): Promise<FillStatus> {
-  const {
-    deposit,
-    fromBlock,
-    destinationChainClient,
-    indexerUrl = MAINNET_INDEXER_API,
-    logger,
-  } = params;
+  const { indexerUrl = MAINNET_INDEXER_API, logger } = params;
 
   try {
     const data = await fetchIndexerApi<IndexerStatusResponse>(
       `${indexerUrl}/deposit/status`,
       {
-        depositId: deposit.depositId,
-        originChainId: deposit.originChainId,
+        depositId: params.deposit.depositId,
+        originChainId: params.deposit.originChainId,
       },
     );
 
     if (data?.status === "filled" && data?.fillTx) {
-      const fillTxReceipt = await destinationChainClient.getTransactionReceipt({
-        hash: data.fillTx,
-      });
-      const fillTxBlock = await destinationChainClient.getBlock({
+      const fillTxReceipt =
+        await params.destinationChainClient.getTransactionReceipt({
+          hash: data.fillTx,
+        });
+      const fillTxBlock = await params.destinationChainClient.getBlock({
         blockNumber: fillTxReceipt.blockNumber,
       });
 
+      const parsedFillEvent = parseFillLogs(fillTxReceipt.logs);
+
       // if message in deposit, check for CallsFailed event
-      if (deposit.message !== "0x") {
+      if (params.deposit.message !== "0x") {
         const [callsFailedLog] = parseEventLogs({
           abi: [
             parseAbiItem(
@@ -70,12 +68,14 @@ export async function getFillByDepositTx(
           actionSuccess: !callsFailedLog,
           fillTxReceipt: fillTxReceipt,
           fillTxTimestamp: fillTxBlock.timestamp,
+          parsedFillEvent,
         };
       }
 
       return {
         fillTxReceipt,
         fillTxTimestamp: fillTxBlock.timestamp,
+        parsedFillEvent,
       };
     }
     // TODO: do we want to handle pending states?
@@ -83,149 +83,29 @@ export async function getFillByDepositTx(
     logger?.warn(`Failed to get fill status from indexer: ${e}`);
   }
 
-  const [fillEvent] = await destinationChainClient.getLogs({
-    address: deposit.destinationSpokePoolAddress,
-    event: {
-      anonymous: false,
-      inputs: [
-        {
-          indexed: false,
-          internalType: "address",
-          name: "inputToken",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "outputToken",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "uint256",
-          name: "inputAmount",
-          type: "uint256",
-        },
-        {
-          indexed: false,
-          internalType: "uint256",
-          name: "outputAmount",
-          type: "uint256",
-        },
-        {
-          indexed: false,
-          internalType: "uint256",
-          name: "repaymentChainId",
-          type: "uint256",
-        },
-        {
-          indexed: true,
-          internalType: "uint256",
-          name: "originChainId",
-          type: "uint256",
-        },
-        {
-          indexed: true,
-          internalType: "uint32",
-          name: "depositId",
-          type: "uint32",
-        },
-        {
-          indexed: false,
-          internalType: "uint32",
-          name: "fillDeadline",
-          type: "uint32",
-        },
-        {
-          indexed: false,
-          internalType: "uint32",
-          name: "exclusivityDeadline",
-          type: "uint32",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "exclusiveRelayer",
-          type: "address",
-        },
-        {
-          indexed: true,
-          internalType: "address",
-          name: "relayer",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "depositor",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "address",
-          name: "recipient",
-          type: "address",
-        },
-        {
-          indexed: false,
-          internalType: "bytes",
-          name: "message",
-          type: "bytes",
-        },
-        {
-          components: [
-            {
-              internalType: "address",
-              name: "updatedRecipient",
-              type: "address",
-            },
-            { internalType: "bytes", name: "updatedMessage", type: "bytes" },
-            {
-              internalType: "uint256",
-              name: "updatedOutputAmount",
-              type: "uint256",
-            },
-            {
-              internalType: "enum V3SpokePoolInterface.FillType",
-              name: "fillType",
-              type: "uint8",
-            },
-          ],
-          indexed: false,
-          internalType: "struct V3SpokePoolInterface.V3RelayExecutionEventInfo",
-          name: "relayExecutionInfo",
-          type: "tuple",
-        },
-      ],
-      name: "FilledV3Relay",
-      type: "event",
-    },
-    args: {
-      depositId: Number(deposit.depositId),
-      originChainId: BigInt(deposit.originChainId),
-    },
-    fromBlock: fromBlock ?? 0n,
-  });
+  const [fillEvent] = await getFillLogs(params);
 
   if (!fillEvent) {
     throw new NoFillLogError(
-      deposit.depositId,
-      deposit.destinationChainId,
-      deposit.depositTxHash,
+      params.deposit.depositId,
+      params.deposit.destinationChainId,
+      params.deposit.depositTxHash,
     );
   }
 
   const [fillTxReceipt, fillBlock] = await Promise.all([
-    destinationChainClient.getTransactionReceipt({
+    params.destinationChainClient.getTransactionReceipt({
       hash: fillEvent.transactionHash,
     }),
-    destinationChainClient.getBlock({
+    params.destinationChainClient.getBlock({
       blockNumber: fillEvent.blockNumber,
     }),
   ]);
 
+  const parsedFillEvent = parseFillLogs(fillTxReceipt.logs);
+
   // if message in deposit, check for CallsFailed event
-  if (deposit.message !== "0x") {
+  if (params.deposit.message !== "0x") {
     const [callsFailedLog] = parseEventLogs({
       abi: [
         parseAbiItem(
@@ -238,12 +118,14 @@ export async function getFillByDepositTx(
       actionSuccess: !callsFailedLog,
       fillTxReceipt: fillTxReceipt,
       fillTxTimestamp: fillBlock.timestamp,
+      parsedFillEvent,
     };
   }
 
   return {
     fillTxReceipt: fillTxReceipt,
     fillTxTimestamp: fillBlock.timestamp,
+    parsedFillEvent,
   };
 }
 
@@ -251,6 +133,7 @@ export type FillStatus = {
   actionSuccess?: boolean; // if deposit has message
   fillTxReceipt: TransactionReceipt;
   fillTxTimestamp: bigint;
+  parsedFillEvent: FillEventLog;
 };
 
 export async function waitForFillByDepositTx(
@@ -278,4 +161,266 @@ export async function waitForFillByDepositTx(
     };
     poll();
   });
+}
+
+export async function getFillLogs(params: GetFillByDepositTxParams) {
+  const { deposit, fromBlock, destinationChainClient } = params;
+  const logs = await Promise.race([
+    destinationChainClient.getLogs({
+      address: deposit.destinationSpokePoolAddress,
+
+      event: {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: false,
+            internalType: "address",
+            name: "inputToken",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "address",
+            name: "outputToken",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "repaymentChainId",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint32",
+            name: "depositId",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "address",
+            name: "exclusiveRelayer",
+            type: "address",
+          },
+          {
+            indexed: true,
+            internalType: "address",
+            name: "relayer",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "address",
+            name: "depositor",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "address",
+            name: "recipient",
+            type: "address",
+          },
+          {
+            indexed: false,
+            internalType: "bytes",
+            name: "message",
+            type: "bytes",
+          },
+          {
+            components: [
+              {
+                internalType: "address",
+                name: "updatedRecipient",
+                type: "address",
+              },
+              { internalType: "bytes", name: "updatedMessage", type: "bytes" },
+              {
+                internalType: "uint256",
+                name: "updatedOutputAmount",
+                type: "uint256",
+              },
+              {
+                internalType: "enum V3SpokePoolInterface.FillType",
+                name: "fillType",
+                type: "uint8",
+              },
+            ],
+            indexed: false,
+            internalType:
+              "struct V3SpokePoolInterface.V3RelayExecutionEventInfo",
+            name: "relayExecutionInfo",
+            type: "tuple",
+          },
+        ],
+        name: "FilledV3Relay",
+        type: "event",
+      },
+      args: {
+        depositId: Number(deposit.depositId),
+        originChainId: BigInt(deposit.originChainId),
+      },
+      fromBlock: fromBlock ?? 0n,
+    }),
+
+    destinationChainClient.getLogs({
+      address: deposit.destinationSpokePoolAddress,
+      event: {
+        anonymous: false,
+        inputs: [
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "inputToken",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "outputToken",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "inputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "outputAmount",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint256",
+            name: "repaymentChainId",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint256",
+            name: "originChainId",
+            type: "uint256",
+          },
+          {
+            indexed: true,
+            internalType: "uint256",
+            name: "depositId",
+            type: "uint256",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "fillDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "uint32",
+            name: "exclusivityDeadline",
+            type: "uint32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "exclusiveRelayer",
+            type: "bytes32",
+          },
+          {
+            indexed: true,
+            internalType: "bytes32",
+            name: "relayer",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "depositor",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "recipient",
+            type: "bytes32",
+          },
+          {
+            indexed: false,
+            internalType: "bytes32",
+            name: "messageHash",
+            type: "bytes32",
+          },
+          {
+            components: [
+              {
+                internalType: "bytes32",
+                name: "updatedRecipient",
+                type: "bytes32",
+              },
+              {
+                internalType: "bytes32",
+                name: "updatedMessageHash",
+                type: "bytes32",
+              },
+              {
+                internalType: "uint256",
+                name: "updatedOutputAmount",
+                type: "uint256",
+              },
+              {
+                internalType: "enum V3SpokePoolInterface.FillType",
+                name: "fillType",
+                type: "uint8",
+              },
+            ],
+            indexed: false,
+            internalType:
+              "struct V3SpokePoolInterface.V3RelayExecutionEventInfo",
+            name: "relayExecutionInfo",
+            type: "tuple",
+          },
+        ],
+        name: "FilledRelay",
+        type: "event",
+      },
+      args: {
+        depositId: deposit.depositId,
+        originChainId: BigInt(deposit.originChainId),
+      },
+      fromBlock: fromBlock ?? 0n,
+    }),
+  ]);
+
+  return logs;
 }

--- a/packages/sdk/src/actions/getSuggestedFees.ts
+++ b/packages/sdk/src/actions/getSuggestedFees.ts
@@ -150,10 +150,7 @@ export async function getSuggestedFees({
 }: GetSuggestedFeesParams) {
   const data = await fetchAcrossApi<SuggestedFeesResponse>(
     `${apiUrl}/suggested-fees`,
-    {
-      depositMethod: "depositExclusive",
-      ...params,
-    },
+    params,
     logger,
   );
 

--- a/packages/sdk/src/actions/signUpdateDeposit.ts
+++ b/packages/sdk/src/actions/signUpdateDeposit.ts
@@ -1,12 +1,10 @@
 import { Address, Hex, WalletClient } from "viem";
-import { getUpdateDepositTypedData } from "../utils/index.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { simulateUpdateDepositTx } from "./simulateUpdateDepositTx.js";
+import { getUpdateDepositTypedDataV3_5 } from "../utils/index.js";
 
 export type SignUpdateDepositTypedDataParams = {
   walletClient: WalletClient;
   depositId: bigint | number;
-  originChainId: number;
+  originChainId: bigint | number;
   updatedMessage: Hex;
   updatedOutputAmount: bigint;
   updatedRecipient: Address;
@@ -38,7 +36,7 @@ export async function signUpdateDepositTypedData(
   }
 
   const signature = await walletClient.signTypedData(
-    getUpdateDepositTypedData({
+    getUpdateDepositTypedDataV3_5({
       signerAddress: account.address,
       originChainId,
       depositId,

--- a/packages/sdk/src/actions/signUpdateDeposit.ts
+++ b/packages/sdk/src/actions/signUpdateDeposit.ts
@@ -5,7 +5,7 @@ import { simulateUpdateDepositTx } from "./simulateUpdateDepositTx.js";
 
 export type SignUpdateDepositTypedDataParams = {
   walletClient: WalletClient;
-  depositId: bigint;
+  depositId: bigint | number;
   originChainId: number;
   updatedMessage: Hex;
   updatedOutputAmount: bigint;

--- a/packages/sdk/src/actions/signUpdateDeposit.ts
+++ b/packages/sdk/src/actions/signUpdateDeposit.ts
@@ -5,7 +5,7 @@ import { simulateUpdateDepositTx } from "./simulateUpdateDepositTx.js";
 
 export type SignUpdateDepositTypedDataParams = {
   walletClient: WalletClient;
-  depositId: number;
+  depositId: bigint;
   originChainId: number;
   updatedMessage: Hex;
   updatedOutputAmount: bigint;

--- a/packages/sdk/src/actions/simulateDepositTx.ts
+++ b/packages/sdk/src/actions/simulateDepositTx.ts
@@ -7,7 +7,7 @@ import {
 } from "viem";
 import { Quote } from "./getQuote.js";
 import { getIntegratorDataSuffix, LoggerT } from "../utils/index.js";
-import { spokePoolAbi } from "../abis/SpokePool.js";
+import { spokePoolAbiV3, spokePoolAbiV4 } from "../abis/SpokePool/index.js";
 
 export type SimulateDepositTxParams = {
   walletClient: WalletClient;
@@ -63,12 +63,12 @@ export async function simulateDepositTx(params: SimulateDepositTxParams) {
         contracts: [
           {
             address: spokePoolAddress,
-            abi: spokePoolAbi,
+            abi: spokePoolAbiV3,
             functionName: "fillDeadlineBuffer",
           },
           {
             address: spokePoolAddress,
-            abi: spokePoolAbi,
+            abi: spokePoolAbiV3,
             functionName: "getCurrentTime",
           },
         ],
@@ -91,9 +91,9 @@ export async function simulateDepositTx(params: SimulateDepositTxParams) {
 
   const result = await publicClient.simulateContract({
     account: walletClient.account,
-    abi: spokePoolAbi,
+    abi: spokePoolAbiV4,
     address: spokePoolAddress,
-    functionName: useExclusiveRelayer ? "depositExclusive" : "depositV3",
+    functionName: "depositV3",
     args: [
       account.address,
       recipient ?? account.address,

--- a/packages/sdk/src/actions/simulateDepositTx.ts
+++ b/packages/sdk/src/actions/simulateDepositTx.ts
@@ -7,7 +7,7 @@ import {
 } from "viem";
 import { Quote } from "./getQuote.js";
 import { getIntegratorDataSuffix, LoggerT } from "../utils/index.js";
-import { spokePoolAbiV3, spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
 
 export type SimulateDepositTxParams = {
   walletClient: WalletClient;
@@ -63,12 +63,12 @@ export async function simulateDepositTx(params: SimulateDepositTxParams) {
         contracts: [
           {
             address: spokePoolAddress,
-            abi: spokePoolAbiV3,
+            abi: spokePoolAbiV4,
             functionName: "fillDeadlineBuffer",
           },
           {
             address: spokePoolAddress,
-            abi: spokePoolAbiV3,
+            abi: spokePoolAbiV4,
             functionName: "getCurrentTime",
           },
         ],

--- a/packages/sdk/src/actions/simulateDepositTx.ts
+++ b/packages/sdk/src/actions/simulateDepositTx.ts
@@ -7,7 +7,7 @@ import {
 } from "viem";
 import { Quote } from "./getQuote.js";
 import { getIntegratorDataSuffix, LoggerT } from "../utils/index.js";
-import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3_5 } from "../abis/SpokePool/index.js";
 
 export type SimulateDepositTxParams = {
   walletClient: WalletClient;
@@ -63,12 +63,12 @@ export async function simulateDepositTx(params: SimulateDepositTxParams) {
         contracts: [
           {
             address: spokePoolAddress,
-            abi: spokePoolAbiV4,
+            abi: spokePoolAbiV3_5,
             functionName: "fillDeadlineBuffer",
           },
           {
             address: spokePoolAddress,
-            abi: spokePoolAbiV4,
+            abi: spokePoolAbiV3_5,
             functionName: "getCurrentTime",
           },
         ],
@@ -91,7 +91,7 @@ export async function simulateDepositTx(params: SimulateDepositTxParams) {
 
   const result = await publicClient.simulateContract({
     account: walletClient.account,
-    abi: spokePoolAbiV4,
+    abi: spokePoolAbiV3_5,
     address: spokePoolAddress,
     functionName: "depositV3",
     args: [

--- a/packages/sdk/src/actions/simulateUpdateDepositTx.ts
+++ b/packages/sdk/src/actions/simulateUpdateDepositTx.ts
@@ -1,7 +1,7 @@
 import { Address, Hex, SimulateContractReturnType, WalletClient } from "viem";
 import { getQuote } from "./getQuote.js";
 import { LoggerT } from "../utils/index.js";
-import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3_5 } from "../abis/SpokePool/index.js";
 import { ConfiguredPublicClient, CrossChainAction } from "../types/index.js";
 import { getDeposit } from "./getDeposit.js";
 import { signUpdateDepositTypedData } from "./signUpdateDeposit.js";
@@ -11,7 +11,7 @@ export type SimulateUpdateDepositTxParams = {
   originChainClient: ConfiguredPublicClient;
   destinationChainClient: ConfiguredPublicClient;
   deposit: {
-    depositId: bigint;
+    depositId: bigint | number;
     originChainId: number;
     destinationChainId: number;
     originSpokePoolAddress: Address;
@@ -150,7 +150,7 @@ export async function simulateUpdateDepositTx(
 
   const result = await originChainClient.simulateContract({
     account,
-    abi: spokePoolAbiV4,
+    abi: spokePoolAbiV3_5,
     address: originSpokePoolAddress,
     functionName: "speedUpV3Deposit",
     args: [

--- a/packages/sdk/src/actions/simulateUpdateDepositTx.ts
+++ b/packages/sdk/src/actions/simulateUpdateDepositTx.ts
@@ -1,7 +1,7 @@
 import { Address, Hex, SimulateContractReturnType, WalletClient } from "viem";
 import { getQuote } from "./getQuote.js";
 import { LoggerT } from "../utils/index.js";
-import { spokePoolAbi } from "../abis/SpokePool.js";
+import { spokePoolAbiV4 } from "../abis/SpokePool/index.js";
 import { ConfiguredPublicClient, CrossChainAction } from "../types/index.js";
 import { getDeposit } from "./getDeposit.js";
 import { signUpdateDepositTypedData } from "./signUpdateDeposit.js";
@@ -11,7 +11,7 @@ export type SimulateUpdateDepositTxParams = {
   originChainClient: ConfiguredPublicClient;
   destinationChainClient: ConfiguredPublicClient;
   deposit: {
-    depositId: number;
+    depositId: bigint;
     originChainId: number;
     destinationChainId: number;
     originSpokePoolAddress: Address;
@@ -150,7 +150,7 @@ export async function simulateUpdateDepositTx(
 
   const result = await originChainClient.simulateContract({
     account,
-    abi: spokePoolAbi,
+    abi: spokePoolAbiV4,
     address: originSpokePoolAddress,
     functionName: "speedUpV3Deposit",
     args: [

--- a/packages/sdk/src/actions/waitForDepositTx.ts
+++ b/packages/sdk/src/actions/waitForDepositTx.ts
@@ -34,5 +34,5 @@ export async function waitForDepositTx(
 
 export type DepositStatus = {
   depositTxReceipt: TransactionReceipt;
-  depositId: number;
+  depositId: bigint;
 };

--- a/packages/sdk/src/actions/waitForFillTx.ts
+++ b/packages/sdk/src/actions/waitForFillTx.ts
@@ -1,11 +1,11 @@
 import { Address, Hash, Hex, parseEventLogs } from "viem";
 import { ConfiguredPublicClient } from "../types/index.js";
-import { spokePoolAbi } from "../abis/SpokePool.js";
+import { spokePoolAbiV3 } from "../abis/SpokePool/index.js";
 import { FillStatus, waitForFillByDepositTx } from "./getFillByDepositTx.js";
 import { LoggerT, MulticallHandlerAbi } from "../utils/index.js";
 
 export type WaitForFillTxParams = {
-  depositId: number;
+  depositId: bigint;
   deposit: {
     originChainId: number;
     destinationChainId: number;
@@ -57,10 +57,10 @@ export async function waitForFillTxEvent(
   return new Promise<FillStatus>((resolve, reject) => {
     const unwatch = destinationChainClient.watchContractEvent({
       address: deposit.destinationSpokePoolAddress,
-      abi: spokePoolAbi,
+      abi: spokePoolAbiV3,
       eventName: "FilledV3Relay",
       args: {
-        depositId,
+        depositId: Number(depositId),
         originChainId: BigInt(deposit.originChainId),
       },
       fromBlock,

--- a/packages/sdk/src/actions/waitForFillTx.ts
+++ b/packages/sdk/src/actions/waitForFillTx.ts
@@ -1,8 +1,12 @@
-import { Address, Hash, Hex, parseEventLogs } from "viem";
+import { Address, Hash, Hex, Log, parseEventLogs } from "viem";
 import { ConfiguredPublicClient } from "../types/index.js";
-import { spokePoolAbiV3 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3, spokePoolAbiV4 } from "../abis/SpokePool/index.js";
 import { FillStatus, waitForFillByDepositTx } from "./getFillByDepositTx.js";
-import { LoggerT, MulticallHandlerAbi } from "../utils/index.js";
+import {
+  bytes32ToAddress,
+  LoggerT,
+  MulticallHandlerAbi,
+} from "../utils/index.js";
 
 export type WaitForFillTxParams = {
   depositId: bigint;
@@ -51,6 +55,25 @@ export async function waitForFillTx(
 export async function waitForFillTxEvent(
   params: WaitForFillTxParams,
 ): Promise<FillStatus> {
+  const { logger } = params;
+
+  try {
+    const status = await Promise.race([
+      waitForV3FillEvent(params),
+      waitForV4FillEvent(params),
+    ]);
+    return status;
+  } catch (error) {
+    logger
+      ? logger.error("Error waiting for fill events", error)
+      : console.error("Error waiting for fill events", error);
+    throw error;
+  }
+}
+
+export async function waitForV3FillEvent(
+  params: WaitForFillTxParams,
+): Promise<FillStatus> {
   const { depositId, destinationChainClient, deposit, fromBlock, logger } =
     params;
 
@@ -75,13 +98,12 @@ export async function waitForFillTxEvent(
       onLogs: async (fillLogs) => {
         if (fillLogs.length) {
           logger
-            ? logger.debug("Fill events found in block", fillLogs)
-            : console.log("Fill events found in block", fillLogs);
+            ? logger.debug("V3 Fill events found in block", fillLogs)
+            : console.log("V3 Fill events found in block", fillLogs);
         }
         const [fillLog] = fillLogs;
         if (fillLog) {
           try {
-            // Retrieve the transaction receipt and block information
             const [fillTxReceipt, fillBlock] = await Promise.all([
               destinationChainClient.getTransactionReceipt({
                 hash: fillLog.transactionHash,
@@ -91,16 +113,14 @@ export async function waitForFillTxEvent(
               }),
             ]);
 
-            // Stop watching
+            const parsedFillEvent = parseFillLogs([fillLog]);
             unwatch();
 
-            // if message in deposit, check for CallsFailed event
             if (deposit.message !== "0x") {
               const logs = parseEventLogs({
                 abi: MulticallHandlerAbi,
                 logs: fillTxReceipt.logs,
               });
-              // TODO: will this fail silently?
 
               logger?.debug("Fill Logs", logs);
 
@@ -111,12 +131,14 @@ export async function waitForFillTxEvent(
                 actionSuccess,
                 fillTxReceipt: fillTxReceipt,
                 fillTxTimestamp: fillBlock.timestamp,
+                parsedFillEvent,
               });
             }
 
             resolve({
               fillTxReceipt,
               fillTxTimestamp: fillBlock.timestamp,
+              parsedFillEvent,
             });
           } catch (error) {
             unwatch();
@@ -127,3 +149,179 @@ export async function waitForFillTxEvent(
     });
   });
 }
+
+export async function waitForV4FillEvent(
+  params: WaitForFillTxParams,
+): Promise<FillStatus> {
+  const { depositId, destinationChainClient, deposit, fromBlock, logger } =
+    params;
+
+  return new Promise<FillStatus>((resolve, reject) => {
+    const unwatch = destinationChainClient.watchContractEvent({
+      address: deposit.destinationSpokePoolAddress,
+      abi: spokePoolAbiV4,
+      eventName: "FilledRelay",
+      args: {
+        depositId: depositId,
+        originChainId: BigInt(deposit.originChainId),
+      },
+      fromBlock,
+      onError: async (error) => {
+        logger
+          ? logger.error("Watch FilledRelay event error", error)
+          : console.error("Watch FilledRelay event error", error);
+
+        unwatch();
+        reject(error);
+      },
+      onLogs: async (fillLogs) => {
+        if (fillLogs.length) {
+          logger
+            ? logger.debug("V4 Fill events found in block", fillLogs)
+            : console.log("V4 Fill events found in block", fillLogs);
+        }
+        const [fillLog] = fillLogs;
+        if (fillLog) {
+          try {
+            const [fillTxReceipt, fillBlock] = await Promise.all([
+              destinationChainClient.getTransactionReceipt({
+                hash: fillLog.transactionHash,
+              }),
+              destinationChainClient.getBlock({
+                blockNumber: fillLog.blockNumber,
+              }),
+            ]);
+            const parsedFillEvent = parseFillLogs([fillLog]);
+
+            unwatch();
+
+            if (deposit.message !== "0x") {
+              const logs = parseEventLogs({
+                abi: MulticallHandlerAbi,
+                logs: fillTxReceipt.logs,
+              });
+
+              logger?.debug("Fill Logs", logs);
+
+              const actionSuccess = !logs.some(
+                (log) => log.eventName === "CallsFailed",
+              );
+              resolve({
+                actionSuccess,
+                fillTxReceipt: fillTxReceipt,
+                fillTxTimestamp: fillBlock.timestamp,
+                parsedFillEvent,
+              });
+            }
+
+            resolve({
+              fillTxReceipt,
+              fillTxTimestamp: fillBlock.timestamp,
+              parsedFillEvent,
+            });
+          } catch (error) {
+            unwatch();
+            reject(error);
+          }
+        }
+      },
+    });
+  });
+}
+
+export function parseFillLogs(
+  logs: Log[],
+  filter?: Partial<{
+    inputToken: Address;
+    outputToken: Address;
+    originChainId: bigint;
+    inputAmount: bigint;
+    outputAmount: bigint;
+    depositor: Address;
+    depositId: bigint;
+  }>,
+) {
+  const blockData = {
+    depositTxHash: logs[0]!.blockHash!,
+    depositTxBlock: logs[0]!.blockNumber!,
+  };
+
+  // Parse V4 Logs
+  const parsedV4Logs = parseEventLogs({
+    abi: spokePoolAbiV4,
+    eventName: "FilledRelay",
+    logs,
+    args: filter,
+  });
+  const v4Log = parsedV4Logs?.[0];
+
+  if (v4Log) {
+    return {
+      ...blockData,
+      inputToken: bytes32ToAddress(v4Log.args.inputToken),
+      outputToken: bytes32ToAddress(v4Log.args.outputToken),
+      inputAmount: v4Log.args.inputAmount,
+      outputAmount: v4Log.args.outputAmount,
+      repaymentChainId: v4Log.args.repaymentChainId,
+      originChainId: v4Log.args.originChainId,
+      depositId: v4Log.args.depositId,
+      fillDeadline: v4Log.args.fillDeadline,
+      exclusivityDeadline: v4Log.args.exclusivityDeadline,
+      exclusiveRelayer: bytes32ToAddress(v4Log.args.exclusiveRelayer),
+      relayer: bytes32ToAddress(v4Log.args.relayer),
+      depositor: bytes32ToAddress(v4Log.args.depositor),
+      recipient: bytes32ToAddress(v4Log.args.recipient),
+      messageHash: v4Log.args.messageHash,
+      relayExecutionInfo: {
+        ...v4Log.args.relayExecutionInfo,
+        updatedRecipient: bytes32ToAddress(
+          v4Log.args.relayExecutionInfo.updatedRecipient,
+        ),
+        fillType: FillType?.[v4Log.args.relayExecutionInfo.fillType],
+      },
+    };
+  }
+
+  // Parse V3 Logs
+  const parsedV3Logs = parseEventLogs({
+    abi: spokePoolAbiV3,
+    eventName: "FilledV3Relay",
+    logs,
+    args: { ...filter, depositId: Number(filter?.depositId) },
+  });
+  const v3Log = parsedV3Logs?.[0];
+
+  if (v3Log) {
+    return {
+      ...blockData,
+      inputToken: v3Log.args.inputToken,
+      outputToken: v3Log.args.outputToken,
+      inputAmount: v3Log.args.inputAmount,
+      outputAmount: v3Log.args.outputAmount,
+      repaymentChainId: v3Log.args.repaymentChainId,
+      originChainId: v3Log.args.originChainId,
+      depositId: v3Log.args.depositId,
+      fillDeadline: v3Log.args.fillDeadline,
+      exclusivityDeadline: v3Log.args.exclusivityDeadline,
+      exclusiveRelayer: v3Log.args.exclusiveRelayer,
+      relayer: v3Log.args.relayer,
+      depositor: v3Log.args.depositor,
+      recipient: v3Log.args.recipient,
+      message: v3Log.args.message,
+      relayExecutionInfo: {
+        ...v3Log.args.relayExecutionInfo,
+        fillType: FillType?.[v3Log.args.relayExecutionInfo.fillType],
+      },
+    };
+  }
+}
+
+export const FillType: { [key: number]: string } = {
+  // Fast fills are normal fills that do not replace a slow fill request.
+  0: "FastFill",
+  // Replaced slow fills are fast fills that replace a slow fill request. This type is used by the Dataworker
+  // to know when to send excess funds from the SpokePool to the HubPool because they can no longer be used
+  // for a slow fill execution.
+  1: "ReplacedSlowFill",
+  2: "SlowFill",
+};

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -680,7 +680,7 @@ export class AcrossClient {
         destinationSpokePoolAddress?: Address;
         originChainId: number;
         destinationChainId: number;
-        depositId?: number;
+        depositId?: bigint;
         depositTxHash?: Hex;
       };
     },

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -127,9 +127,9 @@ export class NoDepositLogError extends Error {
 }
 
 export class NoFillLogError extends Error {
-  constructor(depositId: number, chainId: number, depositTxHash?: Hash) {
+  constructor(depositId: bigint, chainId: number, depositTxHash?: Hash) {
     super(
-      `Unable to find fill log on chain ${chainId} for deposit id #${depositId} ${depositTxHash ? `with depositTxHash ${depositTxHash}` : "."}`,
+      `Unable to find fill log on chain ${chainId} for deposit id #${depositId.toString()} ${depositTxHash ? `with depositTxHash ${depositTxHash}` : "."}`,
     );
     this.name = "Fill Log Not Found";
   }

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -11,8 +11,9 @@ import {
 } from "viem";
 import { STATUS } from "../constants/index.js";
 import { AcrossChain } from "../utils/getSupportedChains.js";
-import { spokePoolAbiV3 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3, spokePoolAbiV4 } from "../abis/SpokePool/index.js";
 import { NoNullValuesOfObject } from "../utils/index.js";
+import { parseFillLogs } from "@/actions/waitForFillTx.js";
 
 export type Status = keyof typeof STATUS;
 
@@ -83,11 +84,18 @@ export type Deposit = DepositLog & {
   actionSuccess?: boolean;
 };
 
+export type FillEventLog = ReturnType<typeof parseFillLogs>;
+
 export type ChainInfoMap = Map<number, AcrossChain>;
 
 type MaybeFilledV3RelayEvent = GetEventArgs<
   typeof spokePoolAbiV3,
   "FilledV3Relay",
+  { IndexedOnly: false }
+>;
+type MaybeFilledRelayEvent = GetEventArgs<
+  typeof spokePoolAbiV4,
+  "FilledRelay",
   { IndexedOnly: false }
 >;
 
@@ -96,5 +104,15 @@ type MaybeDepositV3Event = GetEventArgs<
   "V3FundsDeposited",
   { IndexedOnly: false }
 >;
+
+type MaybeDepositEvent = GetEventArgs<
+  typeof spokePoolAbiV4,
+  "FundsDeposited",
+  { IndexedOnly: false }
+>;
+
 export type FilledV3RelayEvent = NoNullValuesOfObject<MaybeFilledV3RelayEvent>;
 export type V3FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositV3Event>;
+
+export type V4FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
+export type V4FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -11,7 +11,7 @@ import {
 } from "viem";
 import { STATUS } from "../constants/index.js";
 import { AcrossChain } from "../utils/getSupportedChains.js";
-import { spokePoolAbiV3, spokePoolAbiV4 } from "../abis/SpokePool/index.js";
+import { spokePoolAbiV3, spokePoolAbiV3_5 } from "../abis/SpokePool/index.js";
 import { NoNullValuesOfObject } from "../utils/index.js";
 import { parseFillLogs } from "@/actions/waitForFillTx.js";
 
@@ -94,7 +94,7 @@ type MaybeFilledV3RelayEvent = GetEventArgs<
   { IndexedOnly: false }
 >;
 type MaybeFilledRelayEvent = GetEventArgs<
-  typeof spokePoolAbiV4,
+  typeof spokePoolAbiV3_5,
   "FilledRelay",
   { IndexedOnly: false }
 >;
@@ -106,7 +106,7 @@ type MaybeDepositV3Event = GetEventArgs<
 >;
 
 type MaybeDepositEvent = GetEventArgs<
-  typeof spokePoolAbiV4,
+  typeof spokePoolAbiV3_5,
   "FundsDeposited",
   { IndexedOnly: false }
 >;
@@ -114,5 +114,5 @@ type MaybeDepositEvent = GetEventArgs<
 export type FilledV3RelayEvent = NoNullValuesOfObject<MaybeFilledV3RelayEvent>;
 export type V3FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositV3Event>;
 
-export type V4FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
-export type V4FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;
+export type V3_5FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
+export type V3_5FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -11,7 +11,7 @@ import {
 } from "viem";
 import { STATUS } from "../constants/index.js";
 import { AcrossChain } from "../utils/getSupportedChains.js";
-import { spokePoolAbi } from "../abis/SpokePool.js";
+import { spokePoolAbiV3 } from "../abis/SpokePool/index.js";
 import { NoNullValuesOfObject } from "../utils/index.js";
 
 export type Status = keyof typeof STATUS;
@@ -57,14 +57,13 @@ export type TokenInfo = {
   logoUrl: string;
 };
 
-export type Deposit = {
+export type DepositLog = {
   inputToken: Address;
   outputToken: Address;
   inputAmount: bigint;
   outputAmount: bigint;
-  originChainId: number;
   destinationChainId: number;
-  depositId: number;
+  depositId: bigint;
   quoteTimestamp: number;
   fillDeadline: number;
   exclusivityDeadline: number;
@@ -75,6 +74,10 @@ export type Deposit = {
   status: "pending" | "filled";
   depositTxHash: Hash;
   depositTxBlock: bigint;
+};
+
+export type Deposit = DepositLog & {
+  originChainId: number;
   fillTxHash?: Hash;
   fillTxBlock?: bigint;
   actionSuccess?: boolean;
@@ -83,13 +86,13 @@ export type Deposit = {
 export type ChainInfoMap = Map<number, AcrossChain>;
 
 type MaybeFilledV3RelayEvent = GetEventArgs<
-  typeof spokePoolAbi,
+  typeof spokePoolAbiV3,
   "FilledV3Relay",
   { IndexedOnly: false }
 >;
 
 type MaybeDepositV3Event = GetEventArgs<
-  typeof spokePoolAbi,
+  typeof spokePoolAbiV3,
   "V3FundsDeposited",
   { IndexedOnly: false }
 >;

--- a/packages/sdk/src/utils/hex.ts
+++ b/packages/sdk/src/utils/hex.ts
@@ -1,4 +1,4 @@
-import { concat, Hex, isHex } from "viem";
+import { Address, concat, Hex, isAddress, isHex, padHex } from "viem";
 
 export const DOMAIN_CALLDATA_DELIMITER = "0x1dc0de";
 
@@ -32,4 +32,31 @@ export function assertValidIntegratorId(
   }
 
   return true;
+}
+
+export function addressToBytes32(address: Address): Hex {
+  if (!isAddress(address)) {
+    throw new Error("Invalid Address, cannot convert to bytes32");
+  }
+
+  const padded = padHex(address, { dir: "left", size: 32 });
+  return padded;
+}
+
+export function bytes32ToAddress(hex: Hex): Address {
+  if (!isHex(hex)) {
+    throw new Error("Invalid hex input");
+  }
+
+  if (hex.length !== 66) {
+    throw new Error("Hex string must be 32 bytes");
+  }
+
+  const addressHex = `0x${hex.slice(-40)}`;
+
+  if (!isAddress(addressHex)) {
+    throw new Error("Invalid address extracted from bytes32");
+  }
+
+  return addressHex;
 }

--- a/packages/sdk/src/utils/hex.ts
+++ b/packages/sdk/src/utils/hex.ts
@@ -35,6 +35,15 @@ export function assertValidIntegratorId(
 }
 
 export function addressToBytes32(address: Address): Hex {
+  if (!isHex(address)) {
+    throw new Error("Invalid hex input");
+  }
+
+  if (address.length === 66) {
+    // Address is already 32 bytes
+    return address as Hex;
+  }
+
   if (!isAddress(address)) {
     throw new Error("Invalid Address, cannot convert to bytes32");
   }

--- a/packages/sdk/src/utils/typedData.ts
+++ b/packages/sdk/src/utils/typedData.ts
@@ -1,5 +1,9 @@
 import { Address, Hex } from "viem";
+import { addressToBytes32 } from "./hex.js";
 
+/**
+ * @deprecated Use `getUpdateDepositTypedDataV3_5` instead.
+ */
 export function getUpdateDepositTypedData({
   signerAddress,
   originChainId,
@@ -33,10 +37,52 @@ export function getUpdateDepositTypedData({
     },
     primaryType: "UpdateDepositDetails",
     message: {
-      depositId: Number(depositId), // TODO: support new UpdateDepositDetails using bytes32 and uint256 for recipient & depositId, respectively
+      depositId: Number(depositId),
       originChainId: BigInt(originChainId),
       updatedOutputAmount,
       updatedRecipient,
+      updatedMessage,
+    },
+  } as const;
+}
+
+export function getUpdateDepositTypedDataV3_5({
+  signerAddress,
+  originChainId,
+  depositId,
+  updatedMessage,
+  updatedOutputAmount,
+  updatedRecipient,
+}: {
+  signerAddress: Address;
+  originChainId: number | bigint;
+  depositId: number | bigint;
+  updatedOutputAmount: bigint;
+  updatedRecipient: Address;
+  updatedMessage: Hex;
+}) {
+  return {
+    account: signerAddress,
+    domain: {
+      name: "ACROSS-V2",
+      version: "1.0.0",
+      chainId: Number(originChainId),
+    },
+    types: {
+      UpdateDepositDetails: [
+        { name: "depositId", type: "uint256" },
+        { name: "originChainId", type: "uint256" },
+        { name: "updatedOutputAmount", type: "uint256" },
+        { name: "updatedRecipient", type: "bytes32" },
+        { name: "updatedMessage", type: "bytes" },
+      ],
+    },
+    primaryType: "UpdateDepositDetails",
+    message: {
+      depositId: BigInt(depositId),
+      originChainId: BigInt(originChainId),
+      updatedOutputAmount,
+      updatedRecipient: addressToBytes32(updatedRecipient),
       updatedMessage,
     },
   } as const;

--- a/packages/sdk/src/utils/typedData.ts
+++ b/packages/sdk/src/utils/typedData.ts
@@ -10,7 +10,7 @@ export function getUpdateDepositTypedData({
 }: {
   signerAddress: Address;
   originChainId: number;
-  depositId: bigint;
+  depositId: bigint | number;
   updatedOutputAmount: bigint;
   updatedRecipient: Address;
   updatedMessage: Hex;

--- a/packages/sdk/src/utils/typedData.ts
+++ b/packages/sdk/src/utils/typedData.ts
@@ -10,7 +10,7 @@ export function getUpdateDepositTypedData({
 }: {
   signerAddress: Address;
   originChainId: number;
-  depositId: number;
+  depositId: bigint;
   updatedOutputAmount: bigint;
   updatedRecipient: Address;
   updatedMessage: Hex;
@@ -33,7 +33,7 @@ export function getUpdateDepositTypedData({
     },
     primaryType: "UpdateDepositDetails",
     message: {
-      depositId,
+      depositId: Number(depositId), // TODO: support new UpdateDepositDetails using bytes32 and uint256 for recipient & depositId, respectively
       originChainId: BigInt(originChainId),
       updatedOutputAmount,
       updatedRecipient,

--- a/packages/sdk/test/common/anvil.ts
+++ b/packages/sdk/test/common/anvil.ts
@@ -1,9 +1,11 @@
-import { arbitrum, type Chain, mainnet } from "viem/chains";
+import { arbitrum, type Chain, mainnet, sepolia } from "viem/chains";
 import {
   BLOCK_NUMBER_ARBITRUM,
   BLOCK_NUMBER_MAINNET,
+  BLOCK_NUMBER_SEPOLIA,
   FORK_URL_ARBITRUM,
   FORK_URL_MAINNET,
+  FORK_URL_SEPOLIA,
   pool,
   PRIVATE_KEY,
 } from "./constants.js";
@@ -44,7 +46,7 @@ export function getRpcUrls({ port }: { port: number }) {
   } as const;
 }
 
-type Fork = { blockNumber: bigint; url: string; opStack?: boolean };
+export type Fork = { blockNumber: bigint; url: string; opStack?: boolean };
 
 export type AnvilChain = Compute<
   Chain & {
@@ -77,11 +79,11 @@ const arbitrumAnvil = {
   fork: arbitrumFork,
 } as const satisfies AnvilChain;
 
-const account = privateKeyToAccount(PRIVATE_KEY);
+export const testAccount = privateKeyToAccount(PRIVATE_KEY);
 
 // TEST (CHAIN) CLIENTS
 export const chainClientMainnet: ChainClient = createTestClient({
-  account,
+  account: testAccount,
   chain: mainnetAnvil,
   mode: "anvil",
   transport: http(),
@@ -91,7 +93,7 @@ export const chainClientMainnet: ChainClient = createTestClient({
   .extend(walletActions);
 
 export const chainClientArbitrum: ChainClient = createTestClient({
-  account,
+  account: testAccount,
   chain: arbitrumAnvil,
   mode: "anvil",
   transport: http(),
@@ -113,13 +115,13 @@ export const publicClientArbitrum = createPublicClient({
 
 // WALLET CLIENTS
 export const testWalletMainnet = createWalletClient({
-  account,
+  account: testAccount,
   chain: mainnetAnvil,
   transport: http(),
 });
 
 export const testWalletArbitrum = createWalletClient({
-  account,
+  account: testAccount,
   chain: arbitrumAnvil,
   transport: http(),
 });
@@ -134,7 +136,7 @@ export type ChainClient = Client<
 
 type ForkMethods = ReturnType<typeof forkMethods>;
 
-function forkMethods(
+export function forkMethods(
   client: Client<
     Transport,
     AnvilChain,
@@ -180,12 +182,51 @@ function forkMethods(
   };
 }
 
+// Define the Sepolia fork
+export const sepoliaFork = {
+  blockNumber: BLOCK_NUMBER_SEPOLIA,
+  url: FORK_URL_SEPOLIA,
+} as const satisfies Fork;
+
+// Define Sepolia Anvil configuration on PORT: 8549
+export const sepoliaAnvil = {
+  ...sepolia,
+  ...getRpcUrls({ port: 8549 }),
+  fork: sepoliaFork,
+} as const satisfies AnvilChain;
+
+// Create Sepolia Chain Client
+export const chainClientSepolia: ChainClient = createTestClient({
+  account: testAccount,
+  chain: sepoliaAnvil,
+  mode: "anvil",
+  transport: http(),
+})
+  .extend(forkMethods)
+  .extend(publicActions)
+  .extend(walletActions);
+
+// Create Sepolia Public Client
+export const publicClientSepolia = createPublicClient({
+  chain: sepoliaAnvil,
+  transport: http(),
+});
+
+// Create Sepolia Wallet Client
+export const testWalletSepolia = createWalletClient({
+  account: testAccount,
+  chain: sepoliaAnvil,
+  transport: http(),
+});
+
 export const chains = {
   arbitrumAnvil,
   mainnetAnvil,
+  sepoliaAnvil,
 };
 
 export const chainClients: Record<string, ChainClient> = {
   chainClientMainnet,
   chainClientArbitrum,
+  chainClientSepolia,
 };

--- a/packages/sdk/test/common/constants.ts
+++ b/packages/sdk/test/common/constants.ts
@@ -51,8 +51,8 @@ export const FORK_URL_ARBITRUM = `https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY
 // FORK BLOCK NUMBERS
 export const BLOCK_NUMBER_OPTIMISM = BigInt(126951625);
 export const BLOCK_NUMBER_BASE = BigInt(21363706);
-export const BLOCK_NUMBER_MAINNET = BigInt(21020558);
-export const BLOCK_NUMBER_ARBITRUM = BigInt(266447962);
+export const BLOCK_NUMBER_MAINNET = BigInt(21722489);
+export const BLOCK_NUMBER_ARBITRUM = BigInt(300129506);
 
 export const TENDERLY_KEY = getMaybeEnv("VITE_TENDERLY_KEY");
 export const MOCK_API = getMaybeEnv("VITE_MOCK_API") === "true";

--- a/packages/sdk/test/common/constants.ts
+++ b/packages/sdk/test/common/constants.ts
@@ -47,12 +47,14 @@ export const FORK_URL_OPTIMISM = `https://opt-mainnet.g.alchemy.com/v2/${ALCHEMY
 export const FORK_URL_BASE = `https://base-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`;
 export const FORK_URL_MAINNET = `https://eth-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`;
 export const FORK_URL_ARBITRUM = `https://arb-mainnet.g.alchemy.com/v2/${ALCHEMY_KEY}`;
+export const FORK_URL_SEPOLIA = `https://eth-sepolia.g.alchemy.com/v2/${ALCHEMY_KEY}`;
 
 // FORK BLOCK NUMBERS
 export const BLOCK_NUMBER_OPTIMISM = BigInt(126951625);
 export const BLOCK_NUMBER_BASE = BigInt(21363706);
 export const BLOCK_NUMBER_MAINNET = BigInt(21722489);
 export const BLOCK_NUMBER_ARBITRUM = BigInt(300129506);
+export const BLOCK_NUMBER_SEPOLIA = BigInt(7596767);
 
 export const TENDERLY_KEY = getMaybeEnv("VITE_TENDERLY_KEY");
 export const MOCK_API = getMaybeEnv("VITE_MOCK_API") === "true";

--- a/packages/sdk/test/common/relayer.ts
+++ b/packages/sdk/test/common/relayer.ts
@@ -1,4 +1,4 @@
-import type { TransactionReceipt } from "viem";
+import type { Address, TransactionReceipt } from "viem";
 import {
   getDepositFromLogs,
   type AcrossClient,
@@ -6,6 +6,7 @@ import {
 } from "../../src/index.js";
 import type { ChainClient } from "./anvil.js";
 import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
+import { spokePoolAbiV4 } from "../../dist/abis/SpokePool/v4.js";
 
 type RelayerParams = {
   depositReceipt: TransactionReceipt;
@@ -13,11 +14,51 @@ type RelayerParams = {
   originPublicClient: ConfiguredPublicClient;
   destinationPublicClient: ConfiguredPublicClient;
   chainClient: ChainClient;
+  spokePoolAddress?: Address;
 };
 
 // ACROSS RELAYER MOCK
 // waits for deposit TX to succeed, then performs the fill on the destination chain.
-export async function waitForDepositAndFill({
+export async function waitForDepositAndFillV4({
+  depositReceipt,
+  acrossClient,
+  originPublicClient,
+  destinationPublicClient,
+  chainClient,
+  spokePoolAddress,
+}: RelayerParams) {
+  const destinationSpokepoolAddress =
+    spokePoolAddress ??
+    (await acrossClient.getSpokePoolAddress(destinationPublicClient.chain.id));
+
+  const deposit = getDepositFromLogs({
+    originChainId: originPublicClient.chain.id,
+    receipt: depositReceipt,
+  });
+
+  if (!deposit) {
+    throw new Error("Unable to parse deposit logs");
+  }
+
+  const { request } = await destinationPublicClient.simulateContract({
+    address: destinationSpokepoolAddress,
+    abi: spokePoolAbiV4,
+    functionName: "fillV3Relay",
+    args: [
+      {
+        ...deposit,
+        originChainId: BigInt(originPublicClient.chain.id),
+        depositId: Number(deposit.depositId),
+      },
+      BigInt(destinationPublicClient.chain.id),
+    ],
+    account: chainClient.account.address,
+  });
+
+  return await chainClient.writeContract(request);
+}
+
+export async function waitForDepositAndFillV3({
   depositReceipt,
   acrossClient,
   originPublicClient,

--- a/packages/sdk/test/common/relayer.ts
+++ b/packages/sdk/test/common/relayer.ts
@@ -5,7 +5,7 @@ import {
   type ConfiguredPublicClient,
 } from "../../src/index.js";
 import type { ChainClient } from "./anvil.js";
-import { spokePoolAbi } from "../../src/abis/SpokePool.js";
+import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
 
 type RelayerParams = {
   depositReceipt: TransactionReceipt;
@@ -39,7 +39,7 @@ export async function waitForDepositAndFill({
 
   const { request } = await destinationPublicClient.simulateContract({
     address: destinationSpokepoolAddress,
-    abi: spokePoolAbi,
+    abi: spokePoolAbiV3,
     functionName: "fillV3Relay",
     args: [
       { ...deposit, originChainId: BigInt(originPublicClient.chain.id) },

--- a/packages/sdk/test/common/relayer.ts
+++ b/packages/sdk/test/common/relayer.ts
@@ -6,7 +6,7 @@ import {
 } from "../../src/index.js";
 import type { ChainClient } from "./anvil.js";
 import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
-import { spokePoolAbiV4 } from "../../dist/abis/SpokePool/v4.js";
+import { spokePoolAbiV3_5 } from "../../dist/abis/SpokePool/v3_5.js";
 
 type RelayerParams = {
   depositReceipt: TransactionReceipt;
@@ -19,7 +19,7 @@ type RelayerParams = {
 
 // ACROSS RELAYER MOCK
 // waits for deposit TX to succeed, then performs the fill on the destination chain.
-export async function waitForDepositAndFillV4({
+export async function waitForDepositAndFillV3_5({
   depositReceipt,
   acrossClient,
   originPublicClient,
@@ -42,7 +42,7 @@ export async function waitForDepositAndFillV4({
 
   const { request } = await destinationPublicClient.simulateContract({
     address: destinationSpokepoolAddress,
-    abi: spokePoolAbiV4,
+    abi: spokePoolAbiV3_5,
     functionName: "fillV3Relay",
     args: [
       {

--- a/packages/sdk/test/common/relayer.ts
+++ b/packages/sdk/test/common/relayer.ts
@@ -42,7 +42,11 @@ export async function waitForDepositAndFill({
     abi: spokePoolAbiV3,
     functionName: "fillV3Relay",
     args: [
-      { ...deposit, originChainId: BigInt(originPublicClient.chain.id) },
+      {
+        ...deposit,
+        originChainId: BigInt(originPublicClient.chain.id),
+        depositId: Number(deposit.depositId),
+      },
       BigInt(destinationPublicClient.chain.id),
     ],
     account: chainClient.account.address,

--- a/packages/sdk/test/common/sdk.ts
+++ b/packages/sdk/test/common/sdk.ts
@@ -10,6 +10,7 @@ import {
   scroll,
   redstone,
   zora,
+  sepolia,
 } from "viem/chains";
 import { TENDERLY_KEY } from "./constants.js";
 import { MAINNET_API_URL } from "../../src/constants/index.js";
@@ -38,10 +39,18 @@ const tenderly = TENDERLY_KEY
 
 export const TEST_BASE_URL = MAINNET_API_URL;
 
-export const testClient = createAcrossClient({
+export const mainnetTestClient = createAcrossClient({
   useTestnet: false,
   logLevel: "WARN",
   chains: [...MAINNET_SUPPORTED_CHAINS],
+  pollingInterval: 1_000,
+  tenderly,
+});
+
+export const testnetTestClient = createAcrossClient({
+  useTestnet: true,
+  logLevel: "WARN",
+  chains: [sepolia],
   pollingInterval: 1_000,
   tenderly,
 });

--- a/packages/sdk/test/common/upgrade.2025.ts
+++ b/packages/sdk/test/common/upgrade.2025.ts
@@ -1,0 +1,20 @@
+// 2 upgraded mock spoke pools have been deployed to sepolia
+// https://docs.across.to/introduction/migration-guides/migration-guide-for-non-evm-and-prefills/testnet-environment-for-migration
+export const UpgradeTestEnvironment = {
+  spokePool1: {
+    chainId: 11155111,
+    address: "0x1755DD08108095C48509F5C91e071e0cb62eb27a",
+    WETH: {
+      address: "0x43f133FE6fDFA17c417695c476447dc2a449Ba5B",
+      decimals: 18,
+    },
+  },
+  spokePool2: {
+    chainId: 11155112,
+    address: "0xeF89171DBD5DEe4D74842C62689EC0804aF5807B",
+    WETH: {
+      address: "0x5b3acAADE6c53eFCD113dCa116F71312f2df666d",
+      decimals: 18,
+    },
+  },
+} as const;

--- a/packages/sdk/test/e2e/client.test.ts
+++ b/packages/sdk/test/e2e/client.test.ts
@@ -1,14 +1,16 @@
 import { assertType, describe, expect, test } from "vitest";
-import { testClient } from "../common/sdk.js";
+import {
+  MAINNET_SUPPORTED_CHAINS,
+  mainnetTestClient as testClient,
+} from "../common/sdk.js";
 import {
   DefaultLogger,
   type AcrossChain,
   type ConfiguredPublicClient,
 } from "../../src/index.js";
 import type { Address } from "viem";
-import { chains } from "../common/anvil.js";
 
-const chainIds = Object.values(chains).map((chain) => chain.id);
+const chainIds = MAINNET_SUPPORTED_CHAINS.map((chain) => chain.id);
 
 describe("Initialize client", () => {
   test("Client properties set correctly", async () => {

--- a/packages/sdk/test/e2e/executeQuote.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.test.ts
@@ -7,7 +7,7 @@ import {
   expect,
   test,
 } from "vitest";
-import { testClient } from "../common/sdk.js";
+import { mainnetTestClient as testClient } from "../common/sdk.js";
 import {
   type FilledV3RelayEvent,
   type Quote,
@@ -26,7 +26,7 @@ import {
   BLOCK_NUMBER_MAINNET,
 } from "../common/constants.js";
 import { fundUsdc } from "../common/utils.js";
-import { waitForDepositAndFill } from "../common/relayer.js";
+import { waitForDepositAndFillV3 } from "../common/relayer.js";
 import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
 
 const inputToken = {
@@ -85,6 +85,7 @@ describe("executeQuote", async () => {
         chainClientMainnet.resetFork(),
       ]);
     });
+
     beforeAll(async () => {
       // sanity check that we have fresh anvil instances running in this case
       const blockNumberArbitrum = await chainClientArbitrum.getBlockNumber();
@@ -151,7 +152,7 @@ describe("executeQuote", async () => {
               if (progress.status === "txSuccess") {
                 depositTxSuccess = true;
                 const { txReceipt } = progress;
-                const _fillHash = await waitForDepositAndFill({
+                const _fillHash = await waitForDepositAndFillV3({
                   depositReceipt: txReceipt,
                   acrossClient: testClient,
                   originPublicClient: publicClientMainnet,

--- a/packages/sdk/test/e2e/executeQuote.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.test.ts
@@ -123,7 +123,7 @@ describe("executeQuote", async () => {
 
       await new Promise((res, rej) => {
         testClient.executeQuote({
-          deposit: deposit,
+          deposit,
           walletClient: testWalletMainnet,
           // override publicClients because for some reason the configurePublicClients is not respecting the rpcUrls defined for each chain in anvil.ts
           originClient: publicClientMainnet,
@@ -144,6 +144,9 @@ describe("executeQuote", async () => {
             if (progress.step === "deposit") {
               if (progress.status === "simulationSuccess") {
                 depositSimulationSuccess = true;
+              }
+              if (progress.status === "simulationError") {
+                rej(false);
               }
               if (progress.status === "txSuccess") {
                 depositTxSuccess = true;

--- a/packages/sdk/test/e2e/executeQuote.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.test.ts
@@ -27,7 +27,7 @@ import {
 } from "../common/constants.js";
 import { fundUsdc } from "../common/utils.js";
 import { waitForDepositAndFill } from "../common/relayer.js";
-import { spokePoolAbi } from "../../src/abis/SpokePool.js";
+import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
 
 const inputToken = {
   address: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
@@ -180,12 +180,14 @@ describe("executeQuote", async () => {
           })
         : undefined;
 
-      const _fillLog = parseEventLogs({
-        abi: spokePoolAbi,
-        eventName: "FilledV3Relay",
-        logs: fillReceipt?.logs!,
-      });
-      fillLog = _fillLog[0]?.args;
+      const _fillLog =
+        fillReceipt &&
+        parseEventLogs({
+          abi: spokePoolAbiV3,
+          eventName: "FilledV3Relay",
+          logs: fillReceipt?.logs,
+        });
+      fillLog = _fillLog?.[0]?.args;
     });
 
     test("Deposit approval simulation succeeds", async () => {

--- a/packages/sdk/test/e2e/executeQuote.upgrade.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.upgrade.test.ts
@@ -1,0 +1,215 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { testnetTestClient } from "../common/sdk.js";
+import {
+  FillEventLog,
+  getCurrentTimeSeconds,
+  parseFillLogs,
+  type Quote,
+  type Route,
+} from "../../src/index.js";
+import {
+  getAddress,
+  parseEther,
+  parseUnits,
+  zeroAddress,
+  type Hash,
+} from "viem";
+
+import { BLOCK_NUMBER_SEPOLIA } from "../common/constants.js";
+
+import { waitForDepositAndFillV4 } from "../common/relayer.js";
+import {
+  testWalletSepolia,
+  chainClientSepolia,
+  publicClientSepolia,
+} from "../common/anvil.js";
+import { UpgradeTestEnvironment } from "../common/upgrade.2025.js";
+import { fundWeth1, fundWeth2 } from "../common/utils.js";
+
+const { spokePool1, spokePool2 } = UpgradeTestEnvironment;
+
+// WETH Sepolia
+const inputToken = {
+  address: spokePool1.WETH.address,
+  symbol: "WETH",
+  name: "Wrapped Ethereum",
+  decimals: spokePool1.WETH.decimals,
+  logoUrl:
+    "https://raw.githubusercontent.com/across-protocol/frontend/master/src/assets/token-logos/weth.svg",
+} as const;
+
+const inputAmount = 0.001;
+const inputAmountBN = parseUnits(inputAmount.toString(), inputToken.decimals);
+
+const route: Route = {
+  originChainId: spokePool1.chainId,
+  inputToken: spokePool1.WETH.address,
+  destinationChainId: spokePool2.chainId,
+  outputToken: spokePool2.WETH.address,
+  inputTokenSymbol: "WETH",
+  outputTokenSymbol: "WETH",
+  isNative: false,
+} as const;
+
+// NON-Exclusive relayer test
+const _deposit: Quote["deposit"] = {
+  inputAmount: inputAmountBN,
+  outputAmount: inputAmountBN,
+  recipient: getAddress(testWalletSepolia.account.address),
+  message: "0x",
+  quoteTimestamp: getCurrentTimeSeconds(),
+  exclusiveRelayer: zeroAddress,
+  exclusivityDeadline: 0,
+  spokePoolAddress: spokePool1.address,
+  destinationSpokePoolAddress: spokePool2.address,
+  originChainId: spokePool1.chainId,
+  destinationChainId: spokePool2.chainId,
+  inputToken: getAddress(route.inputToken),
+  outputToken: getAddress(route.outputToken),
+  isNative: route.isNative,
+};
+
+let approvalSimulationSuccess = false;
+let approvalTxSuccess = false;
+let depositSimulationSuccess = false;
+let depositTxSuccess = false;
+let fillTxSuccess = false;
+let fillHash: Hash | undefined;
+let fillLog: FillEventLog;
+
+describe("executeQuote", async () => {
+  describe("Executes a quote", async () => {
+    afterAll(async () => {
+      await chainClientSepolia.resetFork();
+    });
+    beforeAll(async () => {
+      // sanity check that we have fresh anvil instances running in this case
+      const blockNumberSepolia = await chainClientSepolia.getBlockNumber();
+      expect(blockNumberSepolia).toBe(BLOCK_NUMBER_SEPOLIA);
+
+      // fund depositor with WETH1 (input token)
+      await fundWeth1({
+        chainClient: chainClientSepolia,
+        walletClient: testWalletSepolia,
+        amount: parseEther("1"),
+      });
+      // fund relayer with WETH2 (outputToken)
+      await fundWeth2({
+        chainClient: chainClientSepolia,
+        walletClient: chainClientSepolia,
+        amount: parseEther("1"),
+      });
+
+      const latestBlock = await chainClientSepolia.getBlock({
+        blockTag: "latest",
+      });
+
+      console.log("Latest block: ", latestBlock);
+
+      // override quote timestamp
+      const deposit = {
+        ..._deposit,
+        quoteTimestamp: Number(latestBlock.timestamp),
+      };
+
+      await new Promise((res, rej) => {
+        testnetTestClient.executeQuote({
+          deposit,
+          walletClient: testWalletSepolia,
+          // override publicClients because for some reason the configurePublicClients is not respecting the rpcUrls defined for each chain in anvil.ts
+          originClient: publicClientSepolia,
+          destinationClient: publicClientSepolia,
+          infiniteApproval: true,
+          onProgress: async (progress) => {
+            console.log(progress);
+
+            if (progress.step === "approve") {
+              if (progress.status === "simulationSuccess") {
+                approvalSimulationSuccess = true;
+              }
+              if (progress.status === "txSuccess") {
+                approvalTxSuccess = true;
+              }
+            }
+
+            if (progress.step === "deposit") {
+              if (progress.status === "simulationSuccess") {
+                depositSimulationSuccess = true;
+              }
+              if (progress.status === "simulationError") {
+                rej(false);
+              }
+              if (progress.status === "txSuccess") {
+                depositTxSuccess = true;
+                const { txReceipt } = progress;
+                const _fillHash = await waitForDepositAndFillV4({
+                  depositReceipt: txReceipt,
+                  acrossClient: testnetTestClient,
+                  originPublicClient: publicClientSepolia,
+                  destinationPublicClient: publicClientSepolia,
+                  chainClient: chainClientSepolia,
+                  spokePoolAddress: spokePool2.address,
+                });
+
+                fillHash = _fillHash;
+              }
+            }
+
+            if (progress.step === "fill") {
+              if (progress.status === "txSuccess") {
+                fillTxSuccess = true;
+                res(true);
+              }
+            }
+
+            if (progress.status === "error") {
+              rej(false);
+            }
+          },
+        });
+      });
+
+      const fillReceipt = fillHash
+        ? await publicClientSepolia.waitForTransactionReceipt({
+            hash: fillHash,
+          })
+        : undefined;
+
+      const _fillLog = fillReceipt && parseFillLogs(fillReceipt?.logs);
+      fillLog = _fillLog;
+    });
+
+    test("Deposit approval simulation succeeds", async () => {
+      expect(approvalSimulationSuccess).toBe(true);
+    });
+    test("Deposit approval tx succeeds", async () => {
+      expect(approvalTxSuccess).toBe(true);
+    });
+    test("Deposit simulation succeeds", async () => {
+      expect(depositSimulationSuccess).toBe(true);
+    });
+    test("Deposit tx succeeds", async () => {
+      expect(depositTxSuccess).toBe(true);
+    });
+
+    test("Fill tx succeeds", async () => {
+      expect(fillTxSuccess).toBe(true);
+    });
+    describe("Fill Logs", async () => {
+      test("Fill Log defined", async () => {
+        expect(fillLog).toBeDefined();
+      });
+      test("Depositor address correct", async () => {
+        expect(getAddress(fillLog?.depositor!)).toBe(
+          testWalletSepolia.account.address,
+        );
+      });
+      test("Output amount correct", async () => {
+        expect(fillLog?.outputAmount).toBe(_deposit.outputAmount);
+      });
+      test("Output token correct", async () => {
+        expect(getAddress(fillLog?.outputToken!)).toBe(_deposit.outputToken);
+      });
+    });
+  });
+});

--- a/packages/sdk/test/e2e/executeQuote.upgrade.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.upgrade.test.ts
@@ -17,7 +17,7 @@ import {
 
 import { BLOCK_NUMBER_SEPOLIA } from "../common/constants.js";
 
-import { waitForDepositAndFillV4 } from "../common/relayer.js";
+import { waitForDepositAndFillV3_5 } from "../common/relayer.js";
 import {
   testWalletSepolia,
   chainClientSepolia,
@@ -142,7 +142,7 @@ describe("executeQuote", async () => {
               if (progress.status === "txSuccess") {
                 depositTxSuccess = true;
                 const { txReceipt } = progress;
-                const _fillHash = await waitForDepositAndFillV4({
+                const _fillHash = await waitForDepositAndFillV3_5({
                   depositReceipt: txReceipt,
                   acrossClient: testnetTestClient,
                   originPublicClient: publicClientSepolia,

--- a/packages/sdk/test/unit/actions/getAvailableRoutes.test.ts
+++ b/packages/sdk/test/unit/actions/getAvailableRoutes.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "vitest";
-import { testClient } from "../../common/sdk.js";
+import { mainnetTestClient as testClient } from "../../common/sdk.js";
 
 // MAINNET => OPTIMISM
 const testnetRoute = {

--- a/packages/sdk/test/unit/actions/getQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getQuote.test.ts
@@ -1,5 +1,5 @@
 import { assert, assertType, describe, test } from "vitest";
-import { testClient } from "../../common/sdk.js";
+import { mainnetTestClient as testClient } from "../../common/sdk.js";
 import {
   buildMulticallHandlerMessage,
   getMultiCallHandlerAddress,

--- a/packages/sdk/test/unit/utils/logger.test.ts
+++ b/packages/sdk/test/unit/utils/logger.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from "vitest";
-import { testClient } from "../../common/sdk.js";
+import { mainnetTestClient as testClient } from "../../common/sdk.js";
 
 test("Higher severity is logged", () => {
   const consoleLogSpy = vi.spyOn(console, "log");


### PR DESCRIPTION
closes ACX-2880
## Motivation

Work done here should allow integrators who use the sdk to smoothly transition through the upgrade. 
We consume, parse old and new Fill and Deposit events.

Tasks;
- [x] Support new Deposit event
- [x] Support new Fill event
- [x] Test backward compatibility
- [x] Test against upgraded spoke pools on testnet