### PR TITLE
depositId as uint256 in speedup typed data

### DIFF
--- a/.changeset/funny-toys-check.md
+++ b/.changeset/funny-toys-check.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+Fix for speed up typed data

--- a/packages/sdk/src/actions/signUpdateDeposit.ts
+++ b/packages/sdk/src/actions/signUpdateDeposit.ts
@@ -54,7 +54,7 @@ export async function signUpdateDepositTypedData(
 
 /**
  * Creates a signature that allows signer to update a deposit. Can be used with
- * `SpokePool` contract's `speedUpV3Deposit` method. Is used internally by
+ * `SpokePool` contract's `speedUpDeposit` method. Is used internally by
  * {@link simulateUpdateDepositTx}
  * @param params See {@link SignUpdateDepositTypedDataParams}
  * @returns Hex-encoded signature

--- a/packages/sdk/src/actions/signUpdateDeposit.ts
+++ b/packages/sdk/src/actions/signUpdateDeposit.ts
@@ -1,5 +1,8 @@
 import { Address, Hex, WalletClient } from "viem";
-import { getUpdateDepositTypedDataV3_5 } from "../utils/index.js";
+import {
+  getUpdateDepositTypedData,
+  getUpdateDepositTypedDataV3_5,
+} from "../utils/index.js";
 
 export type SignUpdateDepositTypedDataParams = {
   walletClient: WalletClient;
@@ -18,6 +21,45 @@ export type SignUpdateDepositTypedDataParams = {
  * @returns Hex-encoded signature
  */
 export async function signUpdateDepositTypedData(
+  params: SignUpdateDepositTypedDataParams,
+) {
+  const {
+    walletClient,
+    depositId,
+    originChainId,
+    updatedMessage,
+    updatedOutputAmount,
+    updatedRecipient,
+  } = params;
+
+  const account = walletClient.account;
+
+  if (!account) {
+    throw new Error("Wallet account has to be set");
+  }
+
+  const signature = await walletClient.signTypedData(
+    getUpdateDepositTypedData({
+      signerAddress: account.address,
+      originChainId,
+      depositId,
+      updatedMessage,
+      updatedOutputAmount,
+      updatedRecipient,
+    }),
+  );
+
+  return signature;
+}
+
+/**
+ * Creates a signature that allows signer to update a deposit. Can be used with
+ * `SpokePool` contract's `speedUpV3Deposit` method. Is used internally by
+ * {@link simulateUpdateDepositTx}
+ * @param params See {@link SignUpdateDepositTypedDataParams}
+ * @returns Hex-encoded signature
+ */
+export async function signUpdateDepositTypedDataV3_5(
   params: SignUpdateDepositTypedDataParams,
 ) {
   const {

--- a/packages/sdk/src/utils/typedData.ts
+++ b/packages/sdk/src/utils/typedData.ts
@@ -1,9 +1,6 @@
 import { Address, Hex } from "viem";
 import { addressToBytes32 } from "./hex.js";
 
-/**
- * @deprecated Use `getUpdateDepositTypedDataV3_5` instead.
- */
 export function getUpdateDepositTypedData({
   signerAddress,
   originChainId,
@@ -13,7 +10,7 @@ export function getUpdateDepositTypedData({
   updatedRecipient,
 }: {
   signerAddress: Address;
-  originChainId: number;
+  originChainId: bigint | number;
   depositId: bigint | number;
   updatedOutputAmount: bigint;
   updatedRecipient: Address;
@@ -24,11 +21,11 @@ export function getUpdateDepositTypedData({
     domain: {
       name: "ACROSS-V2",
       version: "1.0.0",
-      chainId: originChainId,
+      chainId: Number(originChainId),
     },
     types: {
       UpdateDepositDetails: [
-        { name: "depositId", type: "uint32" },
+        { name: "depositId", type: "uint256" },
         { name: "originChainId", type: "uint256" },
         { name: "updatedOutputAmount", type: "uint256" },
         { name: "updatedRecipient", type: "address" },
@@ -37,7 +34,7 @@ export function getUpdateDepositTypedData({
     },
     primaryType: "UpdateDepositDetails",
     message: {
-      depositId: Number(depositId),
+      depositId: BigInt(depositId),
       originChainId: BigInt(originChainId),
       updatedOutputAmount,
       updatedRecipient,

--- a/packages/sdk/test/common/relayer.ts
+++ b/packages/sdk/test/common/relayer.ts
@@ -1,4 +1,4 @@
-import { zeroAddress, type Address, type TransactionReceipt } from "viem";
+import { type Address, type TransactionReceipt } from "viem";
 import {
   getDepositFromLogs,
   type AcrossClient,
@@ -7,6 +7,7 @@ import {
 import type { ChainClient } from "./anvil.js";
 import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
 import { spokePoolAbiV3_5 } from "../../dist/abis/SpokePool/v3_5.js";
+import { isAddressDefined } from "./utils.js";
 
 type RelayerParams = {
   depositReceipt: TransactionReceipt;
@@ -33,7 +34,7 @@ export async function waitForDepositAndFillV3_5({
     spokePoolAddress ??
     (await acrossClient.getSpokePoolAddress(destinationPublicClient.chain.id));
 
-  if (exclusiveRelayer && exclusiveRelayer !== zeroAddress) {
+  if (isAddressDefined(exclusiveRelayer)) {
     await chainClient.impersonateAccount({
       address: exclusiveRelayer,
     });
@@ -60,7 +61,9 @@ export async function waitForDepositAndFillV3_5({
       },
       BigInt(destinationPublicClient.chain.id),
     ],
-    account: exclusiveRelayer || chainClient.account.address,
+    account: isAddressDefined(exclusiveRelayer)
+      ? exclusiveRelayer
+      : chainClient.account.address,
   });
 
   return await chainClient.writeContract(request);

--- a/packages/sdk/test/common/utils.ts
+++ b/packages/sdk/test/common/utils.ts
@@ -1,12 +1,17 @@
 import {
   parseEther,
   WalletClient,
+  zeroAddress,
   type Address,
   type PublicClient,
 } from "viem";
 import { USDC_MAINNET, USDC_WHALE } from "./constants.js";
 import { type ChainClient } from "./anvil.js";
 import { UpgradeTestEnvironment } from "./upgrade.2025.js";
+
+export function isAddressDefined(address?: Address): address is Address {
+  return address && address !== "0x" && address !== zeroAddress ? true : false;
+}
 
 export function sleep(ms: number) {
   return new Promise((resolve) => {

--- a/packages/sdk/test/e2e/executeQuote.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.test.ts
@@ -26,7 +26,7 @@ import {
   BLOCK_NUMBER_MAINNET,
 } from "../common/constants.js";
 import { fundUsdc } from "../common/utils.js";
-import { waitForDepositAndFillV3 } from "../common/relayer.js";
+import { waitForDepositAndFillV3_5 } from "../common/relayer.js";
 import { spokePoolAbiV3 } from "../../src/abis/SpokePool/index.js";
 
 const inputToken = {
@@ -64,6 +64,7 @@ describe("executeQuote", async () => {
     const [_route] = await testClient.getAvailableRoutes(testRoute);
     assert(_route !== undefined, "route is not defined");
     assertType<Route>(_route);
+    console.log(_route);
     route = _route;
   });
 
@@ -75,6 +76,7 @@ describe("executeQuote", async () => {
 
     assert(_quote, "No quote for route");
     assertType<Quote>(_quote);
+    console.log(_quote);
     quote = _quote;
   });
 
@@ -108,7 +110,6 @@ describe("executeQuote", async () => {
           value: parseEther("1"),
         }),
       ]);
-
       // fund test wallet clients with 1000 USDC
       await fundUsdc(chainClientMainnet, testWalletMainnet.account.address);
 
@@ -152,12 +153,13 @@ describe("executeQuote", async () => {
               if (progress.status === "txSuccess") {
                 depositTxSuccess = true;
                 const { txReceipt } = progress;
-                const _fillHash = await waitForDepositAndFillV3({
+                const _fillHash = await waitForDepositAndFillV3_5({
                   depositReceipt: txReceipt,
                   acrossClient: testClient,
                   originPublicClient: publicClientMainnet,
                   destinationPublicClient: publicClientArbitrum,
                   chainClient: chainClientArbitrum,
+                  exclusiveRelayer: deposit.exclusiveRelayer,
                 });
 
                 fillHash = _fillHash;


### PR DESCRIPTION
Small fix: the sdk is still using `depositV3()` and thus for speedups we need to sign a slightly different version of  typed data, where depositId is `uint256`, but the updated recipient is still `address`.
We have both new and old methods available. 