### PR TITLE
Api tests

### DIFF
--- a/.changeset/heavy-experts-mate.md
+++ b/.changeset/heavy-experts-mate.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+Adds tests for API queries.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -54,7 +54,8 @@
     "typedoc-plugin-markdown": "^4.4.1",
     "typescript": "^5.3.3",
     "viem": "^2.20.1",
-    "vitest": "^2.0.5"
+    "vitest": "^2.0.5",
+    "zod": "^3.24.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/sdk/src/actions/getAvailableRoutes.ts
+++ b/packages/sdk/src/actions/getAvailableRoutes.ts
@@ -2,6 +2,7 @@ import { Address } from "viem";
 import { LoggerT, fetchAcrossApi } from "../utils/index.js";
 import { Route } from "../types/index.js";
 import { MAINNET_API_URL } from "../constants/index.js";
+import { AvailableRoutesApiResponse } from "../api/available-routes.js";
 
 export type RoutesQueryParams = Partial<{
   /**
@@ -66,13 +67,3 @@ export async function getAvailableRoutes({
     outputTokenSymbol: route.destinationTokenSymbol,
   }));
 }
-
-type AvailableRoutesApiResponse = {
-  originChainId: number;
-  originToken: string;
-  destinationChainId: number;
-  destinationToken: string;
-  originTokenSymbol: string;
-  destinationTokenSymbol: string;
-  isNative: boolean;
-}[];

--- a/packages/sdk/src/api/available-routes.ts
+++ b/packages/sdk/src/api/available-routes.ts
@@ -1,0 +1,16 @@
+import { boolean, string, z } from "zod";
+import { ethereumAddress, positiveInteger } from "./validators.js";
+
+export const routeSchema = z.array(
+  z.object({
+    originChainId: positiveInteger,
+    originToken: ethereumAddress,
+    destinationChainId: positiveInteger,
+    destinationToken: ethereumAddress,
+    originTokenSymbol: string(),
+    destinationTokenSymbol: string(),
+    isNative: boolean(),
+  }),
+);
+
+export type AvailableRoutesApiResponse = z.infer<typeof routeSchema>;

--- a/packages/sdk/src/api/suggested-fees.ts
+++ b/packages/sdk/src/api/suggested-fees.ts
@@ -1,0 +1,54 @@
+import z from "zod";
+import {
+  percentageString,
+  bigNumberString,
+  numericString,
+  ethereumAddress,
+  positiveInteger,
+} from "./validators.js";
+
+export const suggestedFeesResponseJsonSchema = z.object({
+  estimatedFillTimeSec: positiveInteger,
+  capitalFeePct: percentageString,
+  capitalFeeTotal: bigNumberString,
+  relayGasFeePct: percentageString,
+  relayGasFeeTotal: bigNumberString,
+  relayFeePct: percentageString,
+  relayFeeTotal: bigNumberString,
+  lpFeePct: percentageString,
+  timestamp: numericString,
+  isAmountTooLow: z.boolean(),
+  quoteBlock: numericString,
+  exclusiveRelayer: ethereumAddress,
+  exclusivityDeadline: z.number(),
+  spokePoolAddress: ethereumAddress,
+  destinationSpokePoolAddress: ethereumAddress,
+  totalRelayFee: z.object({
+    pct: percentageString,
+    total: bigNumberString,
+  }),
+  relayerCapitalFee: z.object({
+    pct: percentageString,
+    total: bigNumberString,
+  }),
+  relayerGasFee: z.object({
+    pct: percentageString,
+    total: bigNumberString,
+  }),
+  lpFee: z.object({
+    pct: percentageString,
+    total: bigNumberString,
+  }),
+  limits: z.object({
+    minDeposit: bigNumberString,
+    maxDeposit: bigNumberString,
+    maxDepositInstant: bigNumberString,
+    maxDepositShortDelay: bigNumberString,
+    recommendedDepositInstant: bigNumberString,
+  }),
+  fillDeadline: numericString,
+});
+
+export type SuggestedFeesApiResponse = z.infer<
+  typeof suggestedFeesResponseJsonSchema
+>;

--- a/packages/sdk/src/api/validators.ts
+++ b/packages/sdk/src/api/validators.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+
+export const positiveInteger = z.number().int().nonnegative();
+
+// 20 bytes
+export const ethereumAddress = z.string().regex(/^0x[a-fA-F0-9]{40}$/, {
+  message: "Invalid Ethereum address format",
+});
+
+export const bigNumberString = z.string().regex(/^\d+$/, {
+  message: "Invalid BigNumber string format",
+});
+
+export const percentageString = z.string().regex(/^\d+(\.\d+)?$/, {
+  message: "Invalid percentage string format",
+});
+
+export const numericString = z.string().regex(/^\d+$/, {
+  message: "Invalid numeric string format",
+});

--- a/packages/sdk/test/common/utils.ts
+++ b/packages/sdk/test/common/utils.ts
@@ -167,3 +167,42 @@ export async function fundWeth({
     console.log(e);
   }
 }
+
+/**
+ * Recursively checks if all fields in the `raw` object are present in the `parsed` object.
+ *
+ * @param raw - The original object containing the fields to check.
+ * @param parsed - The object to validate against, ensuring it contains all fields from `raw`.
+ * @returns `true` if all fields in `raw` are present in `parsed`, otherwise `false`.
+ */
+export function checkFields(raw: unknown, parsed: unknown): boolean {
+  // If raw is not an object, there's nothing to check
+  if (typeof raw !== "object" || raw === null) {
+    return true;
+  }
+
+  // If parsed is not an object while raw is, it's a mismatch
+  if (typeof parsed !== "object" || parsed === null) {
+    return false;
+  }
+
+  for (const key of Object.keys(raw)) {
+    if (!(key in (parsed as Record<string, unknown>))) {
+      console.log(`Key ${key} from raw is not present in parsed.`);
+      // Field is missing in parsed
+      return false;
+    }
+
+    const rawValue = (raw as Record<string, unknown>)[key];
+    const parsedValue = (parsed as Record<string, unknown>)[key];
+
+    // If the value is an object, perform a recursive check
+    if (typeof rawValue === "object" && rawValue !== null) {
+      if (!checkFields(rawValue, parsedValue)) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}

--- a/packages/sdk/test/unit/api/available-routes.test.ts
+++ b/packages/sdk/test/unit/api/available-routes.test.ts
@@ -1,0 +1,61 @@
+import { getAvailableRoutes } from "../../../src/actions/getAvailableRoutes.js";
+import { MAINNET_API_URL } from "../../../src/constants/index.js";
+import { buildSearchParams } from "../../../src/utils/fetch.js";
+import { describe, expect, test } from "vitest";
+import { checkFields } from "../../common/utils.js";
+import {
+  AvailableRoutesApiResponse,
+  routeSchema,
+} from "../../../src/api/available-routes.js";
+
+const params = {
+  originChainId: 1,
+  originTokenSymbol: "WETH",
+  destinationTokenSymbol: "WETH",
+  destinationChainId: 10,
+} as const;
+
+describe("available-routes", async () => {
+  // first test the raw response from the API.
+  // This should fail if any breaking changes are introduced upstream
+  test("Response json matches expected schema", async () => {
+    const response = await fetch(
+      `${MAINNET_API_URL}/available-routes?${buildSearchParams(params)}`,
+    ).then((res) => res.json());
+
+    const validated = routeSchema.safeParse(response);
+
+    if (validated.error) {
+      validated.error.errors.forEach((e) => console.log(e));
+    }
+
+    expect(validated.success).toBe(true);
+  });
+
+  test("All values propagate", async () => {
+    // check that ALL FIELDS PROPAGATE
+    const [parsed, raw] = await Promise.all([
+      getAvailableRoutes({
+        apiUrl: MAINNET_API_URL,
+        ...params,
+      }),
+      fetch(
+        `${MAINNET_API_URL}/available-routes?${buildSearchParams(params)}`,
+      ).then((res) => res.json()),
+    ]);
+
+    const renamedFields = {
+      originToken: "inputToken",
+      destinationToken: "outputToken",
+      originTokenSymbol: "inputTokenSymbol",
+      destinationTokenSymbol: "outputTokenSymbol",
+    };
+
+    const compareRawWithParsed = checkFields(
+      (raw as AvailableRoutesApiResponse)[0],
+      parsed[0],
+      renamedFields,
+    );
+    expect(compareRawWithParsed).toBe(true);
+  });
+});

--- a/packages/sdk/test/unit/api/suggested-fees.test.ts
+++ b/packages/sdk/test/unit/api/suggested-fees.test.ts
@@ -1,0 +1,48 @@
+import { getSuggestedFees } from "../../../src/actions/getSuggestedFees.js";
+import { suggestedFeesResponseJsonSchema } from "../../../src/api/suggested-fees.js";
+import { MAINNET_API_URL } from "../../../src/constants/index.js";
+import { buildSearchParams } from "../../../src/utils/fetch.js";
+import { describe, expect, test } from "vitest";
+import { checkFields } from "../../common/utils.js";
+
+const params = {
+  originChainId: 1,
+  inputToken: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
+  outputToken: "0x4200000000000000000000000000000000000006",
+  destinationChainId: 10,
+  amount: "2000000000000000000",
+} as const;
+
+describe("suggested-fees", async () => {
+  // first test the raw response from the API.
+  // This should fail if any breaking changes are introduced upstream
+  test("Response json matches expected schema", async () => {
+    const response = await fetch(
+      `${MAINNET_API_URL}/suggested-fees?${buildSearchParams(params)}`,
+    ).then((res) => res.json());
+
+    const validated = suggestedFeesResponseJsonSchema.safeParse(response);
+
+    if (validated.error) {
+      validated.error.errors.forEach((e) => console.log(e));
+    }
+
+    expect(validated.success).toBe(true);
+  });
+
+  test("All values propagate", async () => {
+    // check that ALL FIELDS PROPAGATE
+    const [parsed, raw] = await Promise.all([
+      getSuggestedFees({
+        apiUrl: MAINNET_API_URL,
+        ...params,
+      }),
+      fetch(
+        `${MAINNET_API_URL}/suggested-fees?${buildSearchParams(params)}`,
+      ).then((res) => res.json()),
+    ]);
+
+    const compareRawWithParsed = checkFields(raw, parsed);
+    expect(compareRawWithParsed).toBe(true);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,7 +55,7 @@ importers:
         version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@rainbow-me/rainbowkit':
         specifier: ^2.1.5
-        version: 2.1.5(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))(wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)))
+        version: 2.1.5(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2))
       '@tanstack/react-query':
         specifier: ^5.52.2
         version: 5.52.2(react@18.3.1)
@@ -100,10 +100,10 @@ importers:
         version: 3.1.0(react@18.3.1)
       viem:
         specifier: ^2.20.1
-        version: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+        version: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       wagmi:
         specifier: ^2.12.25
-        version: 2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))
+        version: 2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)
     devDependencies:
       '@across-toolkit/eslint-config':
         specifier: workspace:*
@@ -210,10 +210,13 @@ importers:
         version: 5.3.3
       viem:
         specifier: ^2.20.1
-        version: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+        version: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       vitest:
         specifier: ^2.0.5
         version: 2.0.5(@types/node@20.17.16)(terser@5.37.0)
+      zod:
+        specifier: ^3.24.2
+        version: 3.24.2
 
   packages/typescript-config: {}
 
@@ -7570,6 +7573,9 @@ packages:
     resolution: {integrity: sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==}
     engines: {node: '>=18'}
 
+  zod@3.24.2:
+    resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
+
   zustand@5.0.0:
     resolution: {integrity: sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==}
     engines: {node: '>=12.20.0'}
@@ -10232,7 +10238,7 @@ snapshots:
 
   '@radix-ui/rect@1.1.0': {}
 
-  '@rainbow-me/rainbowkit@2.1.5(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))(wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)))':
+  '@rainbow-me/rainbowkit@2.1.5(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2))':
     dependencies:
       '@tanstack/react-query': 5.52.2(react@18.3.1)
       '@vanilla-extract/css': 1.14.0
@@ -10244,8 +10250,8 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       react-remove-scroll: 2.5.7(@types/react@18.3.4)(react@18.3.1)
       ua-parser-js: 1.0.38
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
-      wagmi: 2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))
+      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      wagmi: 2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)
     transitivePeerDependencies:
       - '@types/react'
 
@@ -10601,9 +10607,9 @@ snapshots:
 
   '@rushstack/eslint-patch@1.5.1': {}
 
-  '@safe-global/safe-apps-provider@0.18.3(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)':
+  '@safe-global/safe-apps-provider@0.18.3(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       events: 3.3.0
     transitivePeerDependencies:
       - bufferutil
@@ -10611,10 +10617,10 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)':
+  '@safe-global/safe-apps-sdk@9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)':
     dependencies:
       '@safe-global/safe-gateway-typescript-sdk': 3.22.2
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -11186,16 +11192,16 @@ snapshots:
       loupe: 3.1.1
       tinyrainbow: 1.2.0
 
-  '@wagmi/connectors@5.3.3(@types/react@18.3.4)(@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))':
+  '@wagmi/connectors@5.3.3(@types/react@18.3.4)(@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)':
     dependencies:
       '@coinbase/wallet-sdk': 4.1.0
       '@metamask/sdk': 0.30.1(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-provider': 0.18.3(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
-      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
-      '@wagmi/core': 2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))
+      '@safe-global/safe-apps-provider': 0.18.3(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@safe-global/safe-apps-sdk': 9.1.0(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
+      '@wagmi/core': 2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))
       '@walletconnect/ethereum-provider': 2.17.0(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(utf-8-validate@5.0.10)
       cbw-sdk: '@coinbase/wallet-sdk@3.9.3'
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -11222,11 +11228,11 @@ snapshots:
       - utf-8-validate
       - zod
 
-  '@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))':
+  '@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))':
     dependencies:
       eventemitter3: 5.0.1
       mipd: 0.0.7(typescript@5.3.3)
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
       zustand: 5.0.0(@types/react@18.3.4)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1))
     optionalDependencies:
       '@tanstack/query-core': 5.52.2
@@ -11547,9 +11553,10 @@ snapshots:
       '@walletconnect/window-getters': 1.0.1
       tslib: 1.14.1
 
-  abitype@1.0.5(typescript@5.3.3):
+  abitype@1.0.5(typescript@5.3.3)(zod@3.24.2):
     optionalDependencies:
       typescript: 5.3.3
+      zod: 3.24.2
 
   abort-controller@3.0.0:
     dependencies:
@@ -16169,14 +16176,14 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.2
 
-  viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10):
+  viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
       '@scure/bip32': 1.4.0
       '@scure/bip39': 1.3.0
-      abitype: 1.0.5(typescript@5.3.3)
+      abitype: 1.0.5(typescript@5.3.3)(zod@3.24.2)
       isows: 1.0.4(ws@8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10))
       webauthn-p256: 0.0.5
       ws: 8.17.1(bufferutil@4.0.8)(utf-8-validate@5.0.10)
@@ -16250,14 +16257,14 @@ snapshots:
 
   vlq@1.0.1: {}
 
-  wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)):
+  wagmi@2.12.25(@tanstack/query-core@5.52.2)(@tanstack/react-query@5.52.2(react@18.3.1))(@types/react@18.3.4)(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2):
     dependencies:
       '@tanstack/react-query': 5.52.2(react@18.3.1)
-      '@wagmi/connectors': 5.3.3(@types/react@18.3.4)(@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))
-      '@wagmi/core': 2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10))
+      '@wagmi/connectors': 5.3.3(@types/react@18.3.4)(@wagmi/core@2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)))(bufferutil@4.0.8)(react-dom@18.3.1(react@18.3.1))(react-native@0.75.2(@babel/core@7.26.7)(@babel/preset-env@7.25.4(@babel/core@7.26.7))(@types/react@18.3.4)(bufferutil@4.0.8)(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10))(react@18.3.1)(typescript@5.3.3)(utf-8-validate@5.0.10)(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))(zod@3.24.2)
+      '@wagmi/core': 2.14.1(@tanstack/query-core@5.52.2)(@types/react@18.3.4)(react@18.3.1)(typescript@5.3.3)(use-sync-external-store@1.2.0(react@18.3.1))(viem@2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2))
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
-      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)
+      viem: 2.20.1(bufferutil@4.0.8)(typescript@5.3.3)(utf-8-validate@5.0.10)(zod@3.24.2)
     optionalDependencies:
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -16501,6 +16508,8 @@ snapshots:
   yoctocolors-cjs@2.1.2: {}
 
   yoctocolors@2.1.1: {}
+
+  zod@3.24.2: {}
 
   zustand@5.0.0(@types/react@18.3.4)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1)):
     optionalDependencies:


### PR DESCRIPTION
## motivation

This PR adds some tests for API helper functions. These tests should fail if breaking changes are introduced into the API.

NOTE: we sometimes rename some fields when we parse the responses from the api. Annoying but there is a workaround