### PR TITLE
add skipWaitingForFill option to executeQuote

### DIFF
--- a/apps/example/package.json
+++ b/apps/example/package.json
@@ -8,7 +8,7 @@
     "start": "next start",
     "lint": "next lint",
     "sdk": "tsx ./scripts/sdk.ts",
-    "sdk-ethers": "tsx ./scripts/sdk-ethers.ts",
+    "sdk-testnet": "tsx ./scripts/sdk-testnet.ts",
     "ci": "pnpm run build && pnpm run lint"
   },
   "dependencies": {

--- a/apps/example/scripts/sdk-testnet.ts
+++ b/apps/example/scripts/sdk-testnet.ts
@@ -1,0 +1,108 @@
+import { AcrossClient } from "@across-protocol/app-sdk";
+import {
+  Hex,
+  http,
+  createWalletClient,
+  parseUnits,
+  createPublicClient,
+} from "viem";
+import { privateKeyToAccount } from "viem/accounts";
+import { sepolia, baseSepolia } from "viem/chains";
+import { loadEnvConfig } from "@next/env";
+
+const projectDir = process.cwd();
+loadEnvConfig(projectDir);
+
+//  test using client with node
+async function main() {
+  const chains = [sepolia, baseSepolia];
+
+  const PRIVATE_KEY = process.env.DEV_PK
+    ? (process.env.DEV_PK as Hex)
+    : undefined;
+
+  if (!PRIVATE_KEY) {
+    throw new Error("No Private key in ENV");
+  }
+
+  // Read RPC URLs from environment variables
+  const ORIGIN_RPC_URL = process.env.ORIGIN_RPC_URL ;
+  const DESTINATION_RPC_URL = process.env.DESTINATION_RPC_URL;
+
+  // Create a viem wallet client using the private key
+  const account = privateKeyToAccount(PRIVATE_KEY);
+  console.log("Account address: ", account.address);
+
+  const walletClient = createWalletClient({
+    account,
+    chain: sepolia,
+    transport: ORIGIN_RPC_URL ? http(ORIGIN_RPC_URL) : http(),
+  });
+
+  const client = AcrossClient.create({
+    chains,
+    useTestnet: true,
+    logLevel: "ERROR",
+    walletClient,
+  });
+
+  const routeInfo = await client.getAvailableRoutes({
+    originChainId: sepolia.id,
+    destinationChainId: baseSepolia.id,
+    originToken: "0xfFf9976782d46CC05630D1f6eBAb18b2324d6B14", // ETH
+  });
+
+  // Select route
+  console.log(routeInfo);
+  const route = routeInfo[1]; // isNative route
+
+  if (!route) {
+    throw new Error("No routes");
+  }
+
+  const bridgeQuoteRes = await client.getQuote({
+    route,
+    inputAmount: parseUnits("0.00015", 18),
+  });
+  console.log(bridgeQuoteRes);
+
+  const originClient = createPublicClient({
+    chain: sepolia,
+    transport: ORIGIN_RPC_URL ? http(ORIGIN_RPC_URL) : http(),
+  });
+
+  const destinationClient = createPublicClient({
+    chain: baseSepolia,
+    transport: DESTINATION_RPC_URL ? http(DESTINATION_RPC_URL) : http(),
+  });
+
+  const result = await client.executeQuote({
+    walletClient,
+    deposit: bridgeQuoteRes.deposit,
+    originClient: originClient as any,
+    destinationClient: destinationClient as any,
+    onProgress: (progress) => {
+      if (progress.step === "approve" && progress.status === "txSuccess") {
+        // if approving an ERC20, you have access to the approval receipt
+        const { txReceipt } = progress;
+        console.log("Approve successful: ", txReceipt);
+      }
+      if (progress.step === "deposit" && progress.status === "txSuccess") {
+        // once deposit is successful you have access to depositId and the receipt
+        const { depositId, txReceipt } = progress;
+        console.log("Deposit with id: ", depositId);
+        console.log("Deposit Transaction Hash: ", txReceipt.transactionHash);
+      }
+      if (progress.step === "fill" && progress.status === "txSuccess") {
+        // if the fill is successful, you have access the following data
+        const { fillTxTimestamp, txReceipt, actionSuccess } = progress;
+        console.log("Fill Transaction Hash: ", txReceipt.transactionHash);
+        console.log("Action success: ", actionSuccess);
+        // actionSuccess is a boolean flag, telling us if your cross chain messages were successful
+      }
+    },
+    infiniteApproval: false,
+    skipWaitingForFill: true,
+  });
+}
+main();

--- a/packages/sdk/src/actions/executeQuote.ts
+++ b/packages/sdk/src/actions/executeQuote.ts
@@ -146,6 +146,10 @@ export type ExecuteQuoteParams = {
    */
   skipAllowanceCheck?: boolean;
   /**
+   * Whether to skip waiting for the fill transaction.
+   */
+  skipWaitingForFill?: boolean;
+  /**
    * Whether to throw if an error occurs.
    */
   throwOnError?: boolean;
@@ -185,6 +189,7 @@ export async function executeQuote(params: ExecuteQuoteParams) {
     forceOriginChain,
     onProgress,
     logger,
+    skipWaitingForFill = false,
   } = params;
 
   const onProgressHandler =
@@ -359,6 +364,11 @@ export async function executeQuote(params: ExecuteQuoteParams) {
       depositLog,
     };
     onProgressHandler(currentTransactionProgress);
+
+    // Return after deposit is confirmed if so configured
+    if (skipWaitingForFill) {
+      return { depositId, depositTxReceipt };
+    }
 
     // After successful deposit, wait for fill
     currentProgressMeta = {


### PR DESCRIPTION
Introduces the option to skip waiting for the fill Tx when calling executeQuote, that might be useful for some workflows, see https://github.com/across-protocol/toolkit/issues/207.

- Adds new skipWaitingForFill parameter (defaults to false) to executeQuote, if true returns after successful deposit
- Adds new example script [sdk-testnet.ts](https://github.com/across-protocol/toolkit/compare/master...phdargen:toolkit:skipWaitingForFill?expand=1#diff-b4f8fef76dad856b17cf9b9e1319d6473c8672653cbf3b978456a92ebcd58274) to test skipWaitingForFill and testnet transfers more generally