### PR TITLE
support outputAmount

### DIFF
--- a/.changeset/nasty-students-perform.md
+++ b/.changeset/nasty-students-perform.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+Add support for outputAmount field returned by suggested fees. this allows the safe handling of routes where input and output tokens do not have the same decimals

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/app-sdk",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "main": "./dist/index.js",
   "type": "module",
   "description": "The official SDK for integrating Across bridge into your dapp.",

--- a/packages/sdk/src/actions/getLimits.ts
+++ b/packages/sdk/src/actions/getLimits.ts
@@ -1,7 +1,7 @@
 import { Address, Hex } from "viem";
 import { fetchAcrossApi, LoggerT } from "../utils/index.js";
 import { MAINNET_API_URL } from "../constants/index.js";
-import { Amount, BoolString } from "../types/index.js";
+import { Amount } from "../types/index.js";
 
 type LimitsQueryParams = {
   originChainId: number;
@@ -34,7 +34,7 @@ type LimitsQueryParams = {
    * [Optional] Caller specifies whether to includes routes where input token
    * and output token do not have the same decimals
    */
-  allowUnmatchedDecimals?: BoolString;
+  allowUnmatchedDecimals?: boolean;
 };
 
 /**

--- a/packages/sdk/src/actions/getLimits.ts
+++ b/packages/sdk/src/actions/getLimits.ts
@@ -1,7 +1,7 @@
 import { Address, Hex } from "viem";
 import { fetchAcrossApi, LoggerT } from "../utils/index.js";
 import { MAINNET_API_URL } from "../constants/index.js";
-import { Amount } from "../types/index.js";
+import { Amount, BoolString } from "../types/index.js";
 
 type LimitsQueryParams = {
   originChainId: number;
@@ -30,6 +30,11 @@ type LimitsQueryParams = {
    * [Optional] The relayer address to simulate fill with. Defaults to the Across relayer.
    */
   relayer?: Address;
+  /**
+   * [Optional] Caller specifies whether to includes routes where input token
+   * and output token do not have the same decimals
+   */
+  allowUnmatchedDecimals?: BoolString;
 };
 
 /**

--- a/packages/sdk/src/actions/getQuote.ts
+++ b/packages/sdk/src/actions/getQuote.ts
@@ -158,7 +158,7 @@ export async function getQuote(params: GetQuoteParams): Promise<Quote> {
     message,
     logger,
     apiUrl,
-    allowUnmatchedDecimals: "true",
+    allowUnmatchedDecimals: true,
   });
 
   logger?.debug("fees", fees);

--- a/packages/sdk/src/actions/getQuote.ts
+++ b/packages/sdk/src/actions/getQuote.ts
@@ -158,6 +158,7 @@ export async function getQuote(params: GetQuoteParams): Promise<Quote> {
     message,
     logger,
     apiUrl,
+    allowUnmatchedDecimals: "true",
   });
 
   logger?.debug("fees", fees);

--- a/packages/sdk/src/actions/getSuggestedFees.ts
+++ b/packages/sdk/src/actions/getSuggestedFees.ts
@@ -1,6 +1,6 @@
 import { Address } from "viem";
 import { LoggerT, fetchAcrossApi } from "../utils/index.js";
-import { Amount, BoolString } from "../types/index.js";
+import { Amount } from "../types/index.js";
 import { MAINNET_API_URL } from "../constants/index.js";
 import { SuggestedFeesApiResponse } from "../api/suggested-fees.js";
 
@@ -49,7 +49,7 @@ export type SuggestedFeesQueryParams = {
    * [Optional] Caller specifies whether to includes routes where input token
    * and output token do not have the same decimals
    */
-  allowUnmatchedDecimals?: BoolString;
+  allowUnmatchedDecimals?: boolean;
 };
 
 /**

--- a/packages/sdk/src/api/suggested-fees.ts
+++ b/packages/sdk/src/api/suggested-fees.ts
@@ -47,6 +47,19 @@ export const suggestedFeesResponseJsonSchema = z.object({
     recommendedDepositInstant: bigNumberString,
   }),
   fillDeadline: numericString,
+  outputAmount: bigNumberString,
+  inputToken: z.object({
+    address: ethereumAddress,
+    symbol: z.string(),
+    decimals: z.number(),
+    chainId: z.number(),
+  }),
+  outputToken: z.object({
+    address: ethereumAddress,
+    symbol: z.string(),
+    decimals: z.number(),
+    chainId: z.number(),
+  }),
 });
 
 export type SuggestedFeesApiResponse = z.infer<

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -116,5 +116,3 @@ export type V3FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositV3Event>;
 
 export type V3_5FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
 export type V3_5FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;
-
-export type BoolString = "true" | "false";

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -116,3 +116,5 @@ export type V3FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositV3Event>;
 
 export type V3_5FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
 export type V3_5FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;
+
+export type BoolString = "true" | "false";

--- a/packages/sdk/src/utils/fetch.ts
+++ b/packages/sdk/src/utils/fetch.ts
@@ -24,7 +24,7 @@ export function buildSearchParams<
   for (const key in params) {
     const value = params[key];
 
-    if (!value) {
+    if (!isDefined(value)) {
       continue;
     }
 
@@ -43,6 +43,10 @@ export function isOk(res: Response) {
     return true;
   }
   return false;
+}
+
+export function isDefined<T>(value: T): value is NonNullable<T> {
+  return value !== undefined && value !== null ? true : false;
 }
 
 function makeFetcher(

--- a/packages/sdk/test/unit/api/suggested-fees.test.ts
+++ b/packages/sdk/test/unit/api/suggested-fees.test.ts
@@ -1,4 +1,7 @@
-import { getSuggestedFees } from "../../../src/actions/getSuggestedFees.js";
+import {
+  getSuggestedFees,
+  GetSuggestedFeesParams,
+} from "../../../src/actions/getSuggestedFees.js";
 import { suggestedFeesResponseJsonSchema } from "../../../src/api/suggested-fees.js";
 import { MAINNET_API_URL } from "../../../src/constants/index.js";
 import { buildSearchParams } from "../../../src/utils/fetch.js";
@@ -11,7 +14,8 @@ const params = {
   outputToken: "0x4200000000000000000000000000000000000006",
   destinationChainId: 10,
   amount: "2000000000000000000",
-} as const;
+  allowUnmatchedDecimals: true,
+} as const satisfies GetSuggestedFeesParams;
 
 describe("suggested-fees", async () => {
   // first test the raw response from the API.


### PR DESCRIPTION
Add support for new `outputAmount` field returned by suggested-fees.
for convenience functions like `getQuote` we set the default value to` "true"`
In lower level functions like `getSuggestedFees` and `getLimits` we add this as an optional param as per api