### PR TITLE
fix: return executeQuote result to client

### DIFF
--- a/.changeset/three-papayas-tie.md
+++ b/.changeset/three-papayas-tie.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": minor
+---
+
+The executeQuote client function should return a deposit id and deposit/fill transaction receipts.

--- a/packages/sdk/src/actions/executeQuote.ts
+++ b/packages/sdk/src/actions/executeQuote.ts
@@ -164,15 +164,37 @@ export type ExecuteQuoteParams = {
 };
 
 /**
+ * Response parameters for {@link executeQuote}.
+ */
+export type ExecuteQuoteResponseParams = {
+  /**
+   * The ID of the deposit transaction.
+   */
+  depositId?: DepositStatus["depositId"];
+  /**
+   * The receipt of the deposit transaction.
+   */
+  depositTxReceipt?: TransactionReceipt;
+  /**
+   * The receipt of the fill transaction.
+   */
+  fillTxReceipt?: TransactionReceipt;
+  /**
+   * Error object if an error occurred and throwOnError was false.
+   */
+  error?: Error;
+};
+
+/**
  * Executes a quote by:
  * 1. Approving the SpokePool contract if necessary
  * 2. Depositing the input token on the origin chain
  * 3. Waiting for the deposit to be filled on the destination chain
  * @param params - See {@link ExecuteQuoteParams}.
- * @returns The deposit ID and receipts for the deposit and fill transactions.
+ * @returns The deposit ID and receipts for the deposit and fill transactions. See {@link ExecuteQuoteResponseParams}.
  * @public
  */
-export async function executeQuote(params: ExecuteQuoteParams) {
+export async function executeQuote(params: ExecuteQuoteParams): Promise<ExecuteQuoteResponseParams> {
   const {
     integratorId,
     deposit,
@@ -409,7 +431,7 @@ export async function executeQuote(params: ExecuteQuoteParams) {
     });
 
     if (!throwOnError) {
-      return { error };
+      return { error: error as Error };
     }
 
     throw error;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -33,6 +33,7 @@ import {
   SimulateUpdateDepositTxParams,
   signUpdateDepositTypedData,
   SignUpdateDepositTypedDataParams,
+  ExecuteQuoteResponseParams,
 } from "./actions/index.js";
 import {
   MAINNET_API_URL,
@@ -286,7 +287,7 @@ export class AcrossClient {
       ExecuteQuoteParams,
       "logger" | "originClient" | "destinationClient" | "integratorId"
     >,
-  ) {
+  ): Promise<ExecuteQuoteResponseParams> {
     const logger = params?.logger ?? this.logger;
     const originClient =
       params?.originClient ??
@@ -304,7 +305,7 @@ export class AcrossClient {
     }
 
     try {
-      await executeQuote({
+      return await executeQuote({
         ...params,
         integratorId,
         logger,

--- a/packages/sdk/test/e2e/executeQuote.test.ts
+++ b/packages/sdk/test/e2e/executeQuote.test.ts
@@ -9,6 +9,7 @@ import {
 } from "vitest";
 import { mainnetTestClient as testClient } from "../common/sdk.js";
 import {
+  ExecuteQuoteResponseParams,
   parseDepositLogs,
   parseFillLogs,
   type Quote,
@@ -58,6 +59,7 @@ let depositTxSuccess = false;
 let fillTxSuccess = false;
 let depositLog: ReturnType<typeof parseDepositLogs> | undefined;
 let fillLog: ReturnType<typeof parseFillLogs> | undefined;
+let executeQuoteResult: ExecuteQuoteResponseParams;
 
 describe("executeQuote", async () => {
   test("Gets available routes for intent", async () => {
@@ -196,6 +198,8 @@ describe("executeQuote", async () => {
               rej(false);
             }
           },
+        }).then((result: ExecuteQuoteResponseParams) => {
+          executeQuoteResult = result;
         });
       });
     });
@@ -252,6 +256,13 @@ describe("executeQuote", async () => {
           quote.deposit.outputToken,
         );
       });
+    });
+
+    test("ExecuteQuote returns expected result", () => {
+      expect(executeQuoteResult.depositId).toBeDefined();
+      expect(executeQuoteResult.depositTxReceipt).toBeDefined();
+      expect(executeQuoteResult.fillTxReceipt).toBeDefined();
+      expect(executeQuoteResult.error).toBeUndefined();
     });
   });
 });


### PR DESCRIPTION
### Summary
From our documentation, the `executeQuote` client function should return a deposit id and deposit/fill transaction receipts.

```
  /**
   * Execute a quote by:
   * 1. Approving the SpokePool contract if necessary
   * 2. Depositing the input token on the origin chain
   * 3. Waiting for the deposit to be filled on the destination chain
   *
   * See {@link executeQuote} for more details.
   *
   * @example
   * ```ts
   * const quote = await client.getQuote({ route, inputAmount });
   * const { depositId } = await client.executeQuote({ deposit: quote.deposit });
   * ```
   *
   * @param params - See {@link ExecuteQuoteParams}.
   * @returns The deposit ID and receipts for the deposit and fill transactions.
   */
```

https://github.com/across-protocol/toolkit/blob/master/packages/sdk/src/client.ts#L267-L283

I understand that users of the client can track progress using the `onProgress` callback. But I think they should also be able to just call the function and get a response.

### Changes

- Added new type `ExecuteQuoteResponseParams`.
- Used `ExecuteQuoteResponseParams` as the return type in the `executeQuote` action and client function.
- Returned result in the client function.
- Added a test to ensure that the result gets returned and is usable by the caller.