### PR TITLE
better alignment of transactionProgress

### DIFF
--- a/.changeset/flat-icons-perform.md
+++ b/.changeset/flat-icons-perform.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+align progress updates for 5792 deposits


### PR DESCRIPTION
Currently, the transactionProgress shows "approval pending" while executing a batch 5792 approve-deposit call, which could be confusing for users. This updates the transaction stages to reflect the fact that the deposit itself is in progress