### PR TITLE
feat: improve swap quote params + actions support

### DIFF
--- a/.changeset/shaggy-windows-behave.md
+++ b/.changeset/shaggy-windows-behave.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": patch
+---
+
+improve getSwapQuote params

--- a/.changeset/silver-ears-tease.md
+++ b/.changeset/silver-ears-tease.md
@@ -1,0 +1,5 @@
+---
+"@across-protocol/app-sdk": minor
+---
+
+destination chain actions

--- a/packages/sdk/src/actions/getSwapQuote.ts
+++ b/packages/sdk/src/actions/getSwapQuote.ts
@@ -1,15 +1,30 @@
 import { LoggerT, fetchAcrossApi } from "../utils/index.js";
 import { MAINNET_API_URL } from "../constants/index.js";
-import { 
-  BaseSwapQueryParams, 
+import {
+  BaseSwapQueryParams,
   SwapApprovalApiResponse,
-  swapApprovalResponseSchema 
+  swapApprovalResponseSchema,
 } from "../api/swap-approval.js";
+import { Amount } from "../types/index.js";
 
 /**
  * Params for {@link getSwapQuote}.
  */
-export type GetSwapQuoteParams = BaseSwapQueryParams & {
+export type GetSwapQuoteParams = Omit<
+  BaseSwapQueryParams,
+  | "amount"
+  | "originChainId"
+  | "destinationChainId"
+  | "skipOriginTxEstimation"
+  | "slippage"
+  | "appFee"
+> & {
+  amount: Amount;
+  originChainId: number;
+  destinationChainId: number;
+  skipOriginTxEstimation: boolean;
+  slippage: number;
+  appFee: number;
   /**
    * [Optional] The logger to use.
    */
@@ -26,7 +41,9 @@ export type GetSwapQuoteParams = BaseSwapQueryParams & {
  * @returns See {@link SwapApprovalApiResponse}.
  * @public
  */
-export async function getSwapQuote(params: GetSwapQuoteParams): Promise<SwapApprovalApiResponse> {
+export async function getSwapQuote(
+  params: GetSwapQuoteParams,
+): Promise<SwapApprovalApiResponse> {
   const { logger, apiUrl = MAINNET_API_URL, ...queryParams } = params;
 
   logger?.debug("Getting swap quote with params:", queryParams);
@@ -40,8 +57,12 @@ export async function getSwapQuote(params: GetSwapQuoteParams): Promise<SwapAppr
   // Validate the response against our schema
   const validated = swapApprovalResponseSchema.safeParse(data);
   if (!validated.success) {
-    logger?.error(`Invalid swap approval response: ${JSON.stringify(data)}. Error: ${validated.error.message}.`);
-    throw new Error(`Invalid swap approval response. Error: ${validated.error.message}. Please contact support for assistance.`);
+    logger?.error(
+      `Invalid swap approval response: ${JSON.stringify(data)}. Error: ${validated.error.message}.`,
+    );
+    throw new Error(
+      `Invalid swap approval response. Error: ${validated.error.message}. Please contact support for assistance.`,
+    );
   }
 
   return validated.data;

--- a/packages/sdk/src/actions/getSwapQuote.ts
+++ b/packages/sdk/src/actions/getSwapQuote.ts
@@ -6,6 +6,7 @@ import {
   swapApprovalResponseSchema,
 } from "../api/swap-approval.js";
 import { Amount } from "../types/index.js";
+import { Address } from "viem";
 
 /**
  * Params for {@link getSwapQuote}.
@@ -13,6 +14,8 @@ import { Amount } from "../types/index.js";
 export type GetSwapQuoteParams = Omit<
   BaseSwapQueryParams,
   | "amount"
+  | "inputToken"
+  | "outputToken"
   | "originChainId"
   | "destinationChainId"
   | "skipOriginTxEstimation"
@@ -20,8 +23,12 @@ export type GetSwapQuoteParams = Omit<
   | "appFee"
 > & {
   amount: Amount;
-  originChainId: number;
-  destinationChainId: number;
+  route: {
+    originChainId: number;
+    inputToken: Address;
+    destinationChainId: number;
+    outputToken: Address;
+  };
   skipOriginTxEstimation?: boolean;
   slippage?: number;
   appFee?: number;
@@ -48,9 +55,17 @@ export async function getSwapQuote(
 
   logger?.debug("Getting swap quote with params:", queryParams);
 
+  const { route, ...rest } = queryParams;
+  const routeAsQueryParams = {
+    originChainId: route.originChainId,
+    inputToken: route.inputToken,
+    destinationChainId: route.destinationChainId,
+    outputToken: route.outputToken,
+  };
+
   const data = await fetchAcrossApi<SwapApprovalApiResponse>(
     `${apiUrl}/swap/approval`,
-    queryParams,
+    { ...rest, ...routeAsQueryParams },
     logger,
   );
 

--- a/packages/sdk/src/actions/getSwapQuote.ts
+++ b/packages/sdk/src/actions/getSwapQuote.ts
@@ -4,9 +4,8 @@ import {
   BaseSwapQueryParams,
   SwapApprovalApiResponse,
   swapApprovalResponseSchema,
-  Action,
 } from "../api/swap-approval.js";
-import { Amount } from "../types/index.js";
+import { Amount, Action } from "../types/index.js";
 import { Address } from "viem";
 
 /**
@@ -76,7 +75,7 @@ export async function getSwapQuote(
       {
         actions: actions.map((action) => ({
           ...action,
-          value: action.value.toString(),
+          value: action.value?.toString() ?? "0",
         })),
       },
     );

--- a/packages/sdk/src/actions/getSwapQuote.ts
+++ b/packages/sdk/src/actions/getSwapQuote.ts
@@ -22,9 +22,9 @@ export type GetSwapQuoteParams = Omit<
   amount: Amount;
   originChainId: number;
   destinationChainId: number;
-  skipOriginTxEstimation: boolean;
-  slippage: number;
-  appFee: number;
+  skipOriginTxEstimation?: boolean;
+  slippage?: number;
+  appFee?: number;
   /**
    * [Optional] The logger to use.
    */

--- a/packages/sdk/src/api/swap-approval.ts
+++ b/packages/sdk/src/api/swap-approval.ts
@@ -31,26 +31,6 @@ export const baseSwapQueryParamsSchema = z.object({
   strictTradeType: booleanString.optional(),
 });
 
-const actionArgSchema = z.object({
-  value: z.unknown(), // will be validated at runtime
-  populateDynamically: z.boolean().optional(),
-  balanceSourceToken: ethereumAddress.optional(),
-});
-
-const recursiveArgArraySchema = z.union([
-  z.array(actionArgSchema),
-  actionArgSchema,
-]);
-
-const actionSchema = z.object({
-  target: ethereumAddress,
-  functionSignature: z.string().optional().default(""),
-  isNativeTransfer: z.boolean().optional().default(false),
-  args: recursiveArgArraySchema.default([]),
-  value: z.union([bigNumberString, z.bigint()]).default(0n),
-  populateCallValueDynamically: z.boolean().optional(),
-});
-
 // Response schema components
 const feeComponentSchema = z.object({
   amount: bigNumberString,
@@ -250,4 +230,3 @@ export type BaseSwapQueryParams = z.infer<typeof baseSwapQueryParamsSchema>;
 export type SwapApprovalApiResponse = z.infer<
   typeof swapApprovalResponseSchema
 >;
-export type Action = z.infer<typeof actionSchema>;

--- a/packages/sdk/src/api/swap-approval.ts
+++ b/packages/sdk/src/api/swap-approval.ts
@@ -10,7 +10,7 @@ import {
 } from "./validators.js";
 
 // Request schema
-export const BaseSwapQueryParamsSchema = z.object({
+export const baseSwapQueryParamsSchema = z.object({
   amount: positiveIntString,
   tradeType: z.enum(["minOutput", "exactOutput", "exactInput"]).optional(),
   inputToken: ethereumAddress,
@@ -29,6 +29,26 @@ export const BaseSwapQueryParamsSchema = z.object({
   appFee: positiveFloatString(1).optional(),
   appFeeRecipient: ethereumAddress.optional(),
   strictTradeType: booleanString.optional(),
+});
+
+const actionArgSchema = z.object({
+  value: z.unknown(), // will be validated at runtime
+  populateDynamically: z.boolean().optional(),
+  balanceSourceToken: ethereumAddress.optional(),
+});
+
+const recursiveArgArraySchema = z.union([
+  z.array(actionArgSchema),
+  actionArgSchema,
+]);
+
+const actionSchema = z.object({
+  target: ethereumAddress,
+  functionSignature: z.string().optional().default(""),
+  isNativeTransfer: z.boolean().optional().default(false),
+  args: recursiveArgArraySchema.default([]),
+  value: z.union([bigNumberString, z.bigint()]).default(0n),
+  populateCallValueDynamically: z.boolean().optional(),
 });
 
 // Response schema components
@@ -226,7 +246,8 @@ export const swapApprovalResponseSchema = z.object({
   id: z.string().optional(),
 });
 
-export type BaseSwapQueryParams = z.infer<typeof BaseSwapQueryParamsSchema>;
+export type BaseSwapQueryParams = z.infer<typeof baseSwapQueryParamsSchema>;
 export type SwapApprovalApiResponse = z.infer<
   typeof swapApprovalResponseSchema
 >;
+export type Action = z.infer<typeof actionSchema>;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -660,7 +660,7 @@ export class AcrossClient {
     try {
       const quote = await getSwapQuote({
         ...params,
-        skipOriginTxEstimation: "true",
+        skipOriginTxEstimation: true,
         logger: params?.logger ?? this.logger,
         apiUrl: params?.apiUrl ?? this.apiUrl,
       });

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -674,7 +674,7 @@ export class AcrossClient {
       }
 
       const { simulationId, simulationUrl } = await this.simulateTxOnTenderly({
-        networkId: params.destinationChainId.toString(),
+        networkId: params.route.destinationChainId.toString(),
         to: e.transaction.to,
         data: e.transaction.data,
         from: e.transaction.from,

--- a/packages/sdk/src/errors/index.ts
+++ b/packages/sdk/src/errors/index.ts
@@ -37,6 +37,7 @@ export class AcrossApiError extends HttpError {
       url: string;
       message?: string;
       code: AcrossErrorCodeType;
+      requestId?: string;
     },
     opts?: ErrorOptions,
   ) {
@@ -62,6 +63,7 @@ export class AcrossApiSimulationError extends AcrossApiError {
     params: {
       url: string;
       message?: string;
+      requestId?: string;
       transaction: {
         from: Address;
         to: Address;

--- a/packages/sdk/src/types/index.ts
+++ b/packages/sdk/src/types/index.ts
@@ -117,3 +117,39 @@ export type V3FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositV3Event>;
 
 export type V3_5FilledRelayEvent = NoNullValuesOfObject<MaybeFilledRelayEvent>;
 export type V3_5FundsDepositedEvent = NoNullValuesOfObject<MaybeDepositEvent>;
+
+export type ActionArg = {
+  value: unknown;
+  populateDynamically?: boolean;
+  balanceSourceToken?: Address;
+};
+
+export type RecursiveActionArg = ActionArg | ActionArg[];
+
+export type Action =
+  | {
+      target: Address;
+      functionSignature: string;
+      args: ActionArg[];
+      value: bigint;
+      populateCallValueDynamically?: false;
+    }
+  | {
+      target: Address;
+      functionSignature: string;
+      args: ActionArg[];
+      value?: bigint;
+      populateCallValueDynamically: true;
+    }
+  | {
+      target: Address;
+      isNativeTransfer: true;
+      value: bigint;
+      populateCallValueDynamically?: false;
+    }
+  | {
+      target: Address;
+      isNativeTransfer: true;
+      value?: bigint;
+      populateCallValueDynamically: true;
+    };

--- a/packages/sdk/test/unit/actions/getSwapQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getSwapQuote.test.ts
@@ -25,16 +25,16 @@ const inputAmount = 1; // 1 WETH
 describe("getSwapQuote", () => {
   test("Gets a swap quote for a simple bridge transfer", async () => {
     const quote = await getSwapQuote({
-      amount: parseEther(inputAmount.toString()).toString(),
+      amount: parseEther("inputAmount"),
       tradeType: "exactInput",
       inputToken: inputToken.address,
       outputToken: outputToken.address,
-      originChainId: "1", // Mainnet
-      destinationChainId: "10", // Optimism
+      originChainId: 1, // Mainnet
+      destinationChainId: 10, // Optimism
       depositor: testRecipient,
       recipient: testRecipient,
-      slippage: "0.01",
-      appFee: "0.001",
+      slippage: 0.01,
+      appFee: 0.001,
       appFeeRecipient: testRecipient,
     });
 

--- a/packages/sdk/test/unit/actions/getSwapQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getSwapQuote.test.ts
@@ -59,9 +59,7 @@ describe("getSwapQuote", () => {
         {
           target: "0x733Debf51574c70CfCdb7918F032E16F686bd9f8", // Test staking contract on OP
           functionSignature: "function stake(address recipient)",
-          isNativeTransfer: false,
           args: [{ value: testRecipient }],
-          value: 0n,
           populateCallValueDynamically: true,
         },
       ],

--- a/packages/sdk/test/unit/actions/getSwapQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getSwapQuote.test.ts
@@ -20,12 +20,12 @@ const outputToken = {
 } as const;
 
 const testRecipient = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
-const inputAmount = 1; // 1 WETH
+const inputAmount = "1"; // 1 WETH
 
 describe("getSwapQuote", () => {
   test("Gets a swap quote for a simple bridge transfer", async () => {
     const quote = await getSwapQuote({
-      amount: parseEther("inputAmount"),
+      amount: parseEther(inputAmount),
       tradeType: "exactInput",
       inputToken: inputToken.address,
       outputToken: outputToken.address,

--- a/packages/sdk/test/unit/actions/getSwapQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getSwapQuote.test.ts
@@ -27,10 +27,12 @@ describe("getSwapQuote", () => {
     const quote = await getSwapQuote({
       amount: parseEther(inputAmount),
       tradeType: "exactInput",
-      inputToken: inputToken.address,
-      outputToken: outputToken.address,
-      originChainId: 1, // Mainnet
-      destinationChainId: 10, // Optimism
+      route: {
+        originChainId: 1, // Mainnet
+        inputToken: inputToken.address,
+        destinationChainId: 10, // Optimism
+        outputToken: outputToken.address,
+      },
       depositor: testRecipient,
       recipient: testRecipient,
       slippage: 0.01,

--- a/packages/sdk/test/unit/actions/getSwapQuote.test.ts
+++ b/packages/sdk/test/unit/actions/getSwapQuote.test.ts
@@ -20,7 +20,7 @@ const outputToken = {
 } as const;
 
 const testRecipient = "0x9A8f92a830A5cB89a3816e3D267CB7791c16b04D";
-const inputAmount = "1"; // 1 WETH
+const inputAmount = "0.001"; // 0.001 WETH
 
 describe("getSwapQuote", () => {
   test("Gets a swap quote for a simple bridge transfer", async () => {
@@ -38,6 +38,33 @@ describe("getSwapQuote", () => {
       slippage: 0.01,
       appFee: 0.001,
       appFeeRecipient: testRecipient,
+    });
+
+    assert(quote, "No swap quote returned for the provided parameters");
+    assertType<SwapApprovalApiResponse>(quote);
+  });
+
+  test("Gets a swap quote for a simple bridge transfer with actions", async () => {
+    const quote = await getSwapQuote({
+      amount: parseEther(inputAmount),
+      route: {
+        originChainId: 1, // Mainnet
+        inputToken: inputToken.address,
+        destinationChainId: 10, // Optimism
+        outputToken: "0x0000000000000000000000000000000000000000", // Native ETH
+      },
+      depositor: testRecipient,
+      recipient: testRecipient,
+      actions: [
+        {
+          target: "0x733Debf51574c70CfCdb7918F032E16F686bd9f8", // Test staking contract on OP
+          functionSignature: "function stake(address recipient)",
+          isNativeTransfer: false,
+          args: [{ value: testRecipient }],
+          value: 0n,
+          populateCallValueDynamically: true,
+        },
+      ],
     });
 
     assert(quote, "No swap quote returned for the provided parameters");


### PR DESCRIPTION
The Swap API query params types shouldn't need to match 1:1 with the types in the toolkit. Here we can be more strict and can use real booleans, numbers, bigints, etc., without the need for the stringified equivalent.

This also add support for destination chain actions.

Closes ACX-4363