### PR TITLE
fix: pass integratorId to swap API

### DIFF
--- a/packages/sdk/src/actions/getSwapQuote.ts
+++ b/packages/sdk/src/actions/getSwapQuote.ts
@@ -34,6 +34,11 @@ export type GetSwapQuoteParams = Omit<
   appFee?: number;
   actions?: Action[];
   /**
+   * [Optional] Integrator identifier to be forwarded to the swap API so it can
+   * append the integrator tag to the final deposit calldata when applicable.
+   */
+  integratorId?: string;
+  /**
    * [Optional] The logger to use.
    */
   logger?: LoggerT;

--- a/packages/sdk/src/client.ts
+++ b/packages/sdk/src/client.ts
@@ -661,6 +661,7 @@ export class AcrossClient {
       const quote = await getSwapQuote({
         ...params,
         skipOriginTxEstimation: true,
+        integratorId: params?.integratorId ?? this.integratorId,
         logger: params?.logger ?? this.logger,
         apiUrl: params?.apiUrl ?? this.apiUrl,
       });

--- a/packages/sdk/src/utils/hex.ts
+++ b/packages/sdk/src/utils/hex.ts
@@ -1,6 +1,7 @@
 import { Address, concat, Hex, isAddress, isHex, padHex } from "viem";
 
 export const DOMAIN_CALLDATA_DELIMITER = "0x1dc0de";
+export const SWAP_CALLDATA_MARKER = "0x73c0de";
 
 export function tagIntegratorId(integratorId: Hex, txData: Hex) {
   assertValidIntegratorId(integratorId);
@@ -12,6 +13,25 @@ export function getIntegratorDataSuffix(integratorId: Hex) {
   assertValidIntegratorId(integratorId);
 
   return concat([DOMAIN_CALLDATA_DELIMITER, integratorId]);
+}
+
+export function hasIntegratorIdAppended(
+  calldata: Hex,
+  integratorId: Hex,
+  options: {
+    isSwap?: boolean;
+  } = {
+    isSwap: false,
+  },
+): boolean {
+  const integratorIdSuffix = getIntegratorDataSuffix(integratorId);
+  const swapSuffix = SWAP_CALLDATA_MARKER;
+  // swap/approval first appends the integratorId, then the swap marker
+  const suffix = options.isSwap
+    ? concat([integratorIdSuffix, swapSuffix])
+    : integratorIdSuffix;
+
+  return calldata.endsWith(suffix.slice(2));
 }
 
 export function isValidIntegratorId(integratorId: string) {


### PR DESCRIPTION
closes ACP-5

## problem
`getSwapQuote` does not accept the `integratorID` param and thus does not pass it to the swap API.

## Work done
1. getSwapQuote now accepts `integratorID` as param and passes it to swap api to be appended to calldata.
2. Add test.
