### PR TITLE
fix: handle zero swap tx gas value in 'executeSwapQuote'

### DIFF
--- a/packages/sdk/src/actions/executeSwapQuote.ts
+++ b/packages/sdk/src/actions/executeSwapQuote.ts
@@ -13,68 +13,68 @@ export type SwapExecutionProgress = SwapTransactionProgress;
 
 type SwapTransactionProgress =
   | {
-      step: "approve";
-      status: "idle";
-    }
+    step: "approve";
+    status: "idle";
+  }
   | {
-      step: "approve";
-      status: "simulationPending";
-    }
+    step: "approve";
+    status: "simulationPending";
+  }
   | {
-      step: "approve";
-      status: "simulationSuccess";
-    }
+    step: "approve";
+    status: "simulationSuccess";
+  }
   | {
-      step: "approve";
-      status: "txPending";
-      txHash: Hash;
-    }
+    step: "approve";
+    status: "txPending";
+    txHash: Hash;
+  }
   | {
-      step: "approve";
-      status: "txSuccess";
-      txReceipt: TransactionReceipt;
-    }
+    step: "approve";
+    status: "txSuccess";
+    txReceipt: TransactionReceipt;
+  }
   | {
-      step: "swap";
-      status: "idle";
-    }
+    step: "swap";
+    status: "idle";
+  }
   | {
-      step: "swap";
-      status: "simulationPending";
-    }
+    step: "swap";
+    status: "simulationPending";
+  }
   | {
-      step: "swap";
-      status: "simulationSuccess";
-    }
+    step: "swap";
+    status: "simulationSuccess";
+  }
   | {
-      step: "swap";
-      status: "txPending";
-      txHash: Hash;
-    }
+    step: "swap";
+    status: "txPending";
+    txHash: Hash;
+  }
   | {
-      step: "swap";
-      status: "txSuccess";
-      txReceipt: TransactionReceipt;
-      depositId: bigint;
-      depositLog: ReturnType<typeof parseDepositLogs>;
-    }
+    step: "swap";
+    status: "txSuccess";
+    txReceipt: TransactionReceipt;
+    depositId: bigint;
+    depositLog: ReturnType<typeof parseDepositLogs>;
+  }
   | {
-      step: "fill";
-      status: "txPending";
-    }
+    step: "fill";
+    status: "txPending";
+  }
   | {
-      step: "fill";
-      status: "txSuccess";
-      txReceipt: TransactionReceipt;
-      fillTxTimestamp: bigint;
-      actionSuccess: boolean | undefined;
-      fillLog: ReturnType<typeof parseFillLogs>;
-    }
+    step: "fill";
+    status: "txSuccess";
+    txReceipt: TransactionReceipt;
+    fillTxTimestamp: bigint;
+    actionSuccess: boolean | undefined;
+    fillLog: ReturnType<typeof parseFillLogs>;
+  }
   | {
-      step: "approve" | "swap" | "fill";
-      status: "txError" | "error" | "simulationError";
-      error: Error;
-    };
+    step: "approve" | "swap" | "fill";
+    status: "txError" | "error" | "simulationError";
+    error: Error;
+  };
 
 /**
  * Params for {@link executeSwapQuote}.
@@ -269,7 +269,7 @@ export async function executeSwapQuote(
       to: swapTx.to as Address,
       data: swapTx.data as Hex,
       value: swapTx.value ? BigInt(swapTx.value) : 0n,
-      gas: swapTx.gas ? BigInt(swapTx.gas) : undefined,
+      gas: swapTx.gas && BigInt(swapTx.gas) > 0n ? BigInt(swapTx.gas) : undefined,
       maxFeePerGas: swapTx.maxFeePerGas
         ? BigInt(swapTx.maxFeePerGas)
         : undefined,


### PR DESCRIPTION
There's an issue currently when using the `useTestnet: true` flag with certain RPC providers, where viem rejects the swap tx when the `getSwapQuote` call returns `swapTx.quote` as `0n`. 

That's because the current gas conversion logic treats it as a valid value because "0" is a truthy string in JavaScript: `gas: swapTx.gas ? BigInt(swapTx.gas) : undefined`. This produces `gas: 0n`, which gets passed to `originClient.call()` for transaction simulation.

Certain RPC providers (e.g. Alchemy on testnets) reject `eth_call` requests with gas: "0x0", resulting in an `IntrinsicGasTooLowError.`

Explicitly checking for zero-ish `swapTx.gas` fixes the issue and returns `undefined` for `0n` gas values.
 
**Steps to reproduce**
1. Initialize the SDK with `useTestnet: true` and testnet chains (e.g. Base Sepolia, Sepolia);
2. Retrieve a swap quote via `getSwapQuote`;
3. Execute the quote via `executeSwapQuote`;
4. The simulation step fails with `IntrinsicGasTooLowError: The amount of gas provided forthe transaction is too low`;

**Full log:**
```
Error executing
  across quote:  CallExecutionError: The amount of gas provided for the transaction is
  too low.

  Raw Call Arguments:
    from:   0xCAb50e4eb8a04334821Af34838D25bb95a3D8934
    to:     0x8FE6B999Dc680CcFDD5Bf7EB0974218be2542DAA
    value:  0 ETH
    data:   0x8e0250ee0000000000000000000000000000000000000000000000000000000000989680000
  0000000000000000000000000000000000000000000000000000000000000000000000000000000000000ca
  b50e4eb8a04334821af34838d25bb95a3d8934000000000000000000000000036cbd53842c5426634e79295
  41ec2318f3dcf7e000000000000000000000000708704d33ace3dafbed28f150a56ce9d124b1ef800000000
  000000000000000000000000000000000000000000000000000000000000000000000000000000000000000
  0000000000000000000000000000007d01dc0dedead73c0de
    gas:    0

  Details: intrinsic gas too low
  Version: viem@2.33.1
      at async executeAcrossQuote (Bridge.tsx:210:7)
  Caused by: IntrinsicGasTooLowError: The amount of gas provided for the transaction is
  too low.

  Details: intrinsic gas too low
  Version: viem@2.33.1
      at async executeAcrossQuote (Bridge.tsx:210:7)
  Caused by: InvalidInputRpcError: Missing or invalid parameters.
  Double check you have provided the correct parameters.

  URL: https://base-sepolia.g.alchemy.com/v2/XGSPB5uNDfvo4eu9IWk_G
  Request body: {"method":"eth_call","params":[{"data":"0x8e0250ee00000000000000000000000
  000000000000000000000000000000000009896800000000000000000000000000000000000000000000000
  000000000000000000000000000000000000000000cab50e4eb8a04334821af34838d25bb95a3d893400000
  0000000000000000000036cbd53842c5426634e7929541ec2318f3dcf7e0000000000000000000000007087
  04d33ace3dafbed28f150a56ce9d124b1ef8000000000000000000000000000000000000000000000000000
  000000000000000000000000000000000000000000000000000000000000000000000000007d01dc0dedead
  73c0de","from":"0xCAb50e4eb8a04334821Af34838D25bb95a3D8934","gas":"0x0","to":"0x8FE6B99
  9Dc680CcFDD5Bf7EB0974218be2542DAA","value":"0x0"},"latest"]}

  Details: intrinsic gas too low
  Version: viem@2.33.1
  Caused by: RpcRequestError: RPC Request failed.

  URL: https://base-sepolia.g.alchemy.com/v2/XGSPB5uNDfvo4eu9IWk_G
  Request body: {"method":"eth_call","params":[{"data":"0x8e0250ee00000000000000000000000
  000000000000000000000000000000000009896800000000000000000000000000000000000000000000000
  000000000000000000000000000000000000000000cab50e4eb8a04334821af34838d25bb95a3d893400000
  0000000000000000000036cbd53842c5426634e7929541ec2318f3dcf7e0000000000000000000000007087
  04d33ace3dafbed28f150a56ce9d124b1ef8000000000000000000000000000000000000000000000000000
  000000000000000000000000000000000000000000000000000000000000000000000000007d01dc0dedead
  73c0de","from":"0xCAb50e4eb8a04334821Af34838D25bb95a3D8934","gas":"0x0","to":"0x8FE6B99
  9Dc680CcFDD5Bf7EB0974218be2542DAA","value":"0x0"},"latest"]}

  Details: intrinsic gas too low
  Version: viem@2.33.1
  ```