### PR TITLE
ci: bump Node to 24.x to fix release workflow

### DIFF
--- a/.github/workflows/build-lint-test.yml
+++ b/.github/workflows/build-lint-test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
           cache: pnpm
 
       - name: Install Foundry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,14 +22,11 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Setup Node.js 22.x
+      - name: Setup Node.js 24.x
         uses: actions/setup-node@v4
         with:
-          node-version: 22.x
+          node-version: 24.x
           registry-url: "https://registry.npmjs.org"
-
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Install Dependencies
         run: pnpm i


### PR DESCRIPTION
## Summary
- Bump both workflows from Node 22 → 24
- Remove the `Update npm` step in `release.yml`; Node 24 ships with npm 11.x, which already supports trusted publishing

## Why
The release run on master is failing at `npm install -g npm@latest`:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
npm error - .../npm/node_modules/@npmcli/arborist/lib/arborist/rebuild.js
```

This is an npm self-upgrade race: arborist's rebuild step re-requires `promise-retry` while the new npm is overwriting those same files in the global prefix. Bumping Node to 24 removes the need to self-upgrade entirely, since the bundled npm already meets the trusted-publishing minimum (≥ 11.5.1).

Failing run: https://github.com/across-protocol/toolkit/actions/runs/24985150975/job/73156684308

## Test plan
- [ ] `Build Lint & Test` workflow passes on this PR (validates Node 24 for the regular CI path)
- [ ] After merge, confirm the `Release` workflow on master gets past the previously-failing step

🤖 Generated with [Claude Code](https://claude.com/claude-code)